### PR TITLE
Updated getTicks - Condition codes and multiple fields/event types

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,7 +29,7 @@ getBars_Impl <- function(con, security, eventType, barInterval, startDateTime, e
     .Call('Rblpapi_getBars_Impl', PACKAGE = 'Rblpapi', con, security, eventType, barInterval, startDateTime, endDateTime, gapFillInitialBar, verbose)
 }
 
-getTicks_Impl <- function(con, security, eventType, startDateTime, endDateTime, verbose = FALSE) {
-    .Call('Rblpapi_getTicks_Impl', PACKAGE = 'Rblpapi', con, security, eventType, startDateTime, endDateTime, verbose)
+getTicks_Impl <- function(con, security, eventType, startDateTime, endDateTime, setCondCodes = FALSE, verbose = FALSE) {
+    .Call('Rblpapi_getTicks_Impl', PACKAGE = 'Rblpapi', con, security, eventType, startDateTime, endDateTime, setCondCodes, verbose)
 }
 

--- a/R/getTicks.R
+++ b/R/getTicks.R
@@ -3,12 +3,15 @@
 ##'
 ##' @title Get Ticks from Bloomberg
 ##' @param security A character variable describing a valid security ticker
-##' @param eventType A character variable describing an event type;
-##' default is \sQuote{TRADE}
+##' @param eventType A character variable describing an event type. Multiple events can be specified
+##' by a list \code{c("TRADE", "BEST_BID", "BEST_ASK")}, default is \sQuote{TRADE}
 ##' @param startTime A Datetime object with the start time, defaults
 ##' to one hour before current time
 ##' @param endTime A Datetime object with the end time, defaults
 ##' to current time
+##' @param setCondCodes A boolean indicating whether to return any ticks with condition codes,
+##' associated with extraordinary trading and quoting circumstances,
+##' defaults to \sQuote{FALSE}. Similar to setting \code{CondCodes = S} and \code{QRM = S} in Excel API
 ##' @param verbose A boolean indicating whether verbose operation is
 ##' desired, defaults to \sQuote{FALSE}
 ##' @param returnAs A character variable describing the type of return
@@ -23,18 +26,19 @@
 ##' an object of the type selected in \code{returnAs}.
 ##' @author Dirk Eddelbuettel
 getTicks <- function(security,
-                     eventType = "TRADE",
+                     eventType = c("TRADE"),
                      startTime = Sys.time()-60*60,
                      endTime = Sys.time(),
                      verbose = FALSE,
                      returnAs = getOption("blpType", "matrix"),
+                     setCondCodes = FALSE,
                      tz = Sys.getenv("TZ", unset="UTC"),
                      con = .pkgenv$con) {
 
     fmt <- "%Y-%m-%dT%H:%M:%S"
     startUTC <- format(startTime, fmt, tz="UTC")
     endUTC <- format(endTime, fmt, tz="UTC")
-    res <- getTicks_Impl(con, security, eventType, startUTC, endUTC, verbose)
+    res <- getTicks_Impl(con, security, eventType, startUTC, endUTC, setCondCodes, verbose)
 
     attr(res[,1], "tzone") <- tz
     

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -112,18 +112,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // getTicks_Impl
-Rcpp::DataFrame getTicks_Impl(SEXP con, std::string security, std::string eventType, std::string startDateTime, std::string endDateTime, bool verbose);
-RcppExport SEXP Rblpapi_getTicks_Impl(SEXP conSEXP, SEXP securitySEXP, SEXP eventTypeSEXP, SEXP startDateTimeSEXP, SEXP endDateTimeSEXP, SEXP verboseSEXP) {
+Rcpp::DataFrame getTicks_Impl(SEXP con, std::string security, std::vector<std::string> eventType, std::string startDateTime, std::string endDateTime, bool setCondCodes, bool verbose);
+RcppExport SEXP Rblpapi_getTicks_Impl(SEXP conSEXP, SEXP securitySEXP, SEXP eventTypeSEXP, SEXP startDateTimeSEXP, SEXP endDateTimeSEXP, SEXP setCondCodesSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     Rcpp::traits::input_parameter< SEXP >::type con(conSEXP);
     Rcpp::traits::input_parameter< std::string >::type security(securitySEXP);
-    Rcpp::traits::input_parameter< std::string >::type eventType(eventTypeSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type eventType(eventTypeSEXP);
     Rcpp::traits::input_parameter< std::string >::type startDateTime(startDateTimeSEXP);
     Rcpp::traits::input_parameter< std::string >::type endDateTime(endDateTimeSEXP);
+    Rcpp::traits::input_parameter< bool >::type setCondCodes(setCondCodesSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
-    __result = Rcpp::wrap(getTicks_Impl(con, security, eventType, startDateTime, endDateTime, verbose));
+    __result = Rcpp::wrap(getTicks_Impl(con, security, eventType, startDateTime, endDateTime, setCondCodes, verbose));
     return __result;
 END_RCPP
 }


### PR DESCRIPTION
Updated getTicks to support condition code overwrite through a bool toggle, default is `FALSE`.

Multiple field types supported i.e. `eventType = c("TRADE","BEST_ASK","BEST_BID")`. Default is `TRADE`, output in long format.

e.g. `getTicks(con, "XUA Index", eventType = c("BEST_ASK", "BEST_BID"), startDateTime = as.POSIXct("2015-07-07 10:00"), endDateTime = as.POSIXct("2015-07-07 12:00"), setCondCodes = TRUE)`

Doc is updated in getTicks.R