### PR TITLE
cache Bbg header and library (closes #65)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^local
 .travis.yml
 ^deprecated
+^blp
+^inst/blp

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.so
 .Rproj.user
 local/
+blp/
+inst/include/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2015-10-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* configure: Rewritten to (locally) cache the Bloomberg header and
+	and library files making (repeated) builds quicker (issue #65)
+	* src/Makevars.win: Ditto
+
+	* .gitignore: Add blp/ and inst/include/ with cached files
+	* .Rbuildignore: Ditto
+	* cleanup: Adjusted accordingly as well
+
+2015-09-30  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/getTicks.R (getMultipleTicks): In xts mode, make timestamps
+	unique prior to merge to ensure order is preserved (issue #76)
+
 2015-09-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .travis.yml (notifications): Added slack notification

--- a/R/getTicks.R
+++ b/R/getTicks.R
@@ -141,10 +141,9 @@ getMultipleTicks <- function(security,
         ## Use na.locf to carry bid, ask, .. forward, but do not use trade column
         ind <- !grepl("trade", colnames(x))
         x[,ind] <- zoo::na.locf(x[,ind])
-        index(x) <- trunc(index(x))     # remove unique-ified timestamps
-
+        
+        zoo::index(x) <- trunc(zoo::index(x)) # truncated time stamp down to seconds
         return(x)
-
     } 
         
     return(res)

--- a/cleanup
+++ b/cleanup
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-rm -rf src/*.o src/Rblpapi.so src/Rblpapi.dylib src/Rblpapi.dll src/Makevars inst/blp inst/include/
+rm -rf src/*.o src/Rblpapi.so src/Rblpapi.dylib src/Rblpapi.dll src/Makevars \
+   .Rhistory

--- a/configure
+++ b/configure
@@ -60,17 +60,22 @@ else
 fi
 
 ## Get and install header files
-(cd inst; 
-    ${download} https://github.com/Rblp/blp/raw/master/headers/${platform}/blpHeaders.tar.gz; 
-    tar xfz blpHeaders.tar.gz;
-    rm blpHeaders.tar.gz)
+cwd=$(pwd)
+mkdir -p blp/${platform}
+cd blp/${platform}
+if [ ! -f blpHeaders.tar.gz ]; then
+    ${download} https://github.com/Rblp/blp/raw/master/headers/${platform}/blpHeaders.tar.gz
+    tar xfz blpHeaders.tar.gz -C ../../inst
+fi
+cd ${cwd}
 
 ## Get and install precompiled shared library
-(cd inst;
-    mkdir -p blp;
-    cd blp;
+mkdir -p inst/blp
+cd blp/${platform}
+if [ ! -f blpLibrary.tar.gz ]; then
     ${download} https://github.com/Rblp/blp/raw/master/${platform}${flavour}/blpLibrary.tar.gz
-    tar xfz blpLibrary.tar.gz libblpapi3_${flavour}.so
-    rm blpLibrary.tar.gz)
+    tar xfz blpLibrary.tar.gz -C ../../inst/blp/ libblpapi3_${flavour}.so
+fi
+cd ${cwd}
 
 exit 0

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -41,16 +41,14 @@ all:    	blpLibrary $(SHLIB)
 ## in order to see commands as they happens add a 'v' to the tar and cp commands
 ## curl has '-k' flag to suppress certificate warnings
 blpLibrary:
-		@if [ ! -d ../inst ]; then mkdir ../inst; fi
-		@curl -s -k -L -O https://github.com/Rblp/blp/raw/master/headers/windows/blpHeaders.tar.gz
-		@tar xfz blpHeaders.tar.gz -C ../inst
-		@curl -s -k -L -O https://github.com/Rblp/blp/raw/master/win${WIN}/blpLibrary.tar.gz
-		@tar xfz blpLibrary.tar.gz
-		@if [ ! -d ${FLV} ]; then mkdir ${FLV}; fi
+		@if [ ! -d ../inst ]; then mkdir -p ../inst; fi
+		@if [ ! -d ../blp/win/${FLV} ]; then mkdir -p ../blp/win/${FLV}; fi
+		@if [ ! -f ../blp/win/${FLV}/blpHeaders.tar.gz ]; then curl -s -k -L -O https://github.com/Rblp/blp/raw/master/headers/windows/blpHeaders.tar.gz; mv blpHeaders.tar.gz ../blp/win/${FLV}; tar xfz ../blp/win/${FLV}/blpHeaders.tar.gz -C ../inst; fi
+		@if [ ! -f ../blp/win/${FLV}/blpLibrary.tar.gz ]; then curl -s -k -L -O https://github.com/Rblp/blp/raw/master/win${WIN}/blpLibrary.tar.gz; mv blpLibrary.tar.gz ../blp/win/${FLV}; tar xfz ../blp/win/${FLV}/blpLibrary.tar.gz; fi
+		@if [ ! -d ${FLV} ]; then mkdir -p ${FLV}; fi
 		@cp blpapi3_${WIN}.dll ${FLV}
-		@if [ ! -d ../inst/libs ]; then mkdir ../inst/libs; fi
-		@if [ ! -d ../inst/libs/${FLV} ]; then mkdir ../inst/libs/${FLV}; fi
-		@mv blpapi3_${WIN}.dll ../inst/libs/${FLV}
+		@if [ ! -d ../inst/libs/${FLV} ]; then mkdir -p ../inst/libs/${FLV}; fi
+		@cp blpapi3_${WIN}.dll ../inst/libs/${FLV}
 
 ## Ensure the blpLibrary target is always executed
 .Phony:		blpLibrary


### PR DESCRIPTION
via configure (OS X, Linux) and src/Makevars.win
tested successfully on Windows and Linux
adjusted .gitignore, .Rbuildignore and cleanup accordingly
one additional tweak for getTicks.R: call zoo::index explicitly