### PR TITLE
Update bdh.R Example

### DIFF
--- a/R/bdh.R
+++ b/R/bdh.R
@@ -53,7 +53,7 @@
 ##'   ## example for an options field: request monthly data; see section A.2.4 of
 ##'   ##  http://www.bloomberglabs.com/content/uploads/sites/2/2014/07/blpapi-developers-guide-2.54.pdf
 ##'   ## for more 
-##'   opt <- c("periodicityAdjustment"="MONTHLY")
+##'   opt <- c("periodicitySelection"="MONTHLY")
 ##'   bdh("SPY US Equity", c("PX_LAST", "VOLUME"),
 ##'       start.date=Sys.Date()-31*6, options=opt)
 ##' 


### PR DESCRIPTION
The BDH() example for an options field doesn't work as per the manual:

```
>opt <- c("periodicityAdjustment"="MONTHLY")
>bdh("SPY US Equity", c("PX_LAST", "VOLUME"),  start.date=Sys.Date()-31*6, options=opt)

Error: Enumeration type could not be found for MONTHLY
```

The correct override name is **opt <- c("periodicitySelection"="MONTHLY")**

```
>opt <- c("periodicitySelection"="MONTHLY")
>bdh("SPY US Equity", c("PX_LAST", "VOLUME"),  start.date=Sys.Date()-31*6, options=opt)

       date PX_LAST    VOLUME
1  2015-10-16  203.27 114580052
2  2015-10-19  203.37  76523897

```