### PR TITLE
Feature/unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - ./travis-tool.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_aptget r-cran-rcpp r-cran-bh r-cran-knitr
+  - ./travis-tool.sh install_aptget r-cran-rcpp r-cran-bh r-cran-knitr r-cran-runit
 
 script:
   - ./travis-tool.sh run_tests

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2016-02-24  Dirk Eddelbuettel  <deddelbuettel@ketchumtrading.com>
+
+	* DESCRIPTION (Suggests): Added RUnit
+	* .travis.yml: Idem (though tests are skipped at Travis)
+
+	* tests/doRUnit.R: Unit test wrapper using RUnit
+
+	* inst/unitTests/runit.getBars.R: Two new test functions for
+	getBars() as a start; requires ~/.R/rblpapiOptions.R with options()
+
 2016-02-10  Whit Armstrong  <armstrong.whit@gmail.com>
 
 	* src/bdp.cpp: check order of bbg response matches user reqeust order

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: Rblpapi
 Title: R Interface to Bloomberg
-Version: 0.3.2.2
-Date: 2015-12-18
+Version: 0.3.2.3
+Date: 2016-02-24
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils
-Suggests: fts, xts, zoo, knitr
+Suggests: fts, xts, zoo, knitr, RUnit
 VignetteBuilder: knitr
 LazyLoad: yes
 LinkingTo: Rcpp, BH

--- a/inst/unitTests/runit.getBars.R
+++ b/inst/unitTests/runit.getBars.R
@@ -1,0 +1,64 @@
+#!/usr/bin/env r
+# hey emacs, please make this use  -*- tab-width: 4 -*-
+#
+# Copyright (C) 2016   Dirk Eddelbuettel, Whit Armstrong and John Laing
+#
+# This file is part of Rblpapi.
+#
+# Rblpapi is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Rblpapi is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+.runThisTest <- Sys.getenv("RunRblpapiUnitTests") == "yes"
+
+.setUp <- function() {
+    connectionParameterFile <- "~/.R/rblpapiOptions.R"
+    if (file.exists(connectionParameterFile)) {
+        source(connectionParameterFile)
+        Rblpapi::blpConnect()
+    } else {
+        .runThisTest <- FALSE
+    }
+}
+
+if (.runThisTest) {
+
+    test.getBarsAsMatrix <- function() {
+
+        res <- getBars("ES1 Index", returnAs="matrix")
+
+        checkTrue(inherits(res, "data.frame"),
+                  msg = "checking return type")
+
+        checkTrue(dim(res)[1] > 3, msg = "check return of at least three rows")
+        checkTrue(dim(res)[2] == 8, msg = "check return of eight columns")
+
+        checkTrue(all(c("times", "open", "high", "low", "close") %in% colnames(res)),
+                  msg = "check column names")
+
+    }
+
+    test.getBarsAsXts <- function() {
+
+        res <- getBars("ES1 Index", returnAs="xts")
+
+        checkTrue(inherits(res, "xts"),
+                  msg = "checking return type")
+
+        checkTrue(dim(res)[1] > 3, msg = "check return of at least three rows")
+        checkTrue(dim(res)[2] == 7, msg = "check return of seven columns")
+
+        checkTrue(all(c("open", "high", "low", "close") %in% colnames(res)),
+                  msg = "check column names")
+
+    }
+}

--- a/tests/doRUnit.R
+++ b/tests/doRUnit.R
@@ -1,0 +1,62 @@
+## Copyright (C) 2016  Dirk Eddelbuettel, Whit Armstrong and John Laing
+## Based on earlier versions in Rcpp, RProtoBuf and other packages
+##
+## This file is part of Rblpapi
+##
+## Rblpapi is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 2 of the License, or
+## (at your option) any later version.
+##
+## Rblpapi is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+## doRUnit.R --- Run RUnit tests
+##
+## with credits to package fUtilities in RMetrics
+## which credits Gregor Gojanc's example in CRAN package  'gdata'
+## as per the R Wiki http://wiki.r-project.org/rwiki/doku.php?id=developers:runit
+## and changed further by Martin Maechler
+## and more changes by Murray Stokely in HistogramTools
+## and then used adapted in RProtoBuf
+## and then used in Rcpp with two additional env var setters/getters
+##
+## Dirk Eddelbuettel, Feb 2016
+
+stopifnot(require(RUnit, quietly=TRUE))
+stopifnot(require(Rblpapi, quietly=TRUE))
+
+## Set a seed to make the test deterministic
+set.seed(42)
+
+## Define tests
+testSuite <- defineTestSuite(name="Rblpapi Unit Tests",
+                             dirs=system.file("unitTests", package = "Rblpapi"),
+                             testFuncRegexp = "^[Tt]est.+")
+
+## if an option is set, we run tests. otherwise we don't.
+## recall that we DO need a working Bloomberg connection...
+if (TRUE || getOption("blpUnitTests", FALSE)) {
+
+    ## without this, we get (or used to get) unit test failures
+    Sys.setenv("R_TESTS"="")
+
+    Sys.setenv("RunRblpapiUnitTests" = "yes")
+
+    ## Run tests
+    tests <- runTestSuite(testSuite)
+
+    ## Print results
+    printTextProtocol(tests)
+
+    ## Return success or failure to R CMD CHECK
+    if (getErrors(tests)$nFail > 0) stop("TEST FAILED!")
+    if (getErrors(tests)$nErr > 0) stop("TEST HAD ERRORS!")
+    if (getErrors(tests)$nTestFunc < 1) stop("NO TEST FUNCTIONS RUN!")
+}
+

--- a/tests/doRUnit.R
+++ b/tests/doRUnit.R
@@ -41,7 +41,7 @@ testSuite <- defineTestSuite(name="Rblpapi Unit Tests",
 
 ## if an option is set, we run tests. otherwise we don't.
 ## recall that we DO need a working Bloomberg connection...
-if (TRUE || getOption("blpUnitTests", FALSE)) {
+if (getOption("blpUnitTests", FALSE)) {
 
     ## without this, we get (or used to get) unit test failures
     Sys.setenv("R_TESTS"="")


### PR DESCRIPTION
Proof of concept with two functions and eight tests for getBars

Requires that you create `~/.R/rblpapiOptions.R` with the `options()` snippet otherwise in `Rprofile` as the latter is not read during tests.