### PR TITLE
added data.table support to getMultipleTicks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,11 @@
 	possibility of multiple returns
 	* man/getTicks.Rd: Ditto
 
+	* R/getTicks.R: (getMultipleTicks): Changed to support data.frame
+	and data.table support as type and code cannot be represented in
+	numeric matrices
+	* man/getMultipleTicks.Rd: Ditto
+
 2016-09-16  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/getTicks.cpp: Re-enable condition codes for data.frame and

--- a/man/getMultipleTicks.Rd
+++ b/man/getMultipleTicks.Rd
@@ -6,8 +6,8 @@
 \usage{
 getMultipleTicks(security, eventType = c("TRADE", "BID", "ASK"),
   startTime = Sys.time() - 60 * 60, endTime = Sys.time(), verbose = FALSE,
-  returnAs = getOption("blpType", "matrix"), tz = Sys.getenv("TZ", unset =
-  "UTC"), con = defaultConnection())
+  returnAs = getOption("blpType", "data.frame"), tz = Sys.getenv("TZ", unset
+  = "UTC"), con = defaultConnection())
 }
 \arguments{
 \item{security}{A character variable describing a valid security ticker}
@@ -25,9 +25,8 @@ to current time}
 desired, defaults to \sQuote{FALSE}}
 
 \item{returnAs}{A character variable describing the type of return
-object; the default is return a matrix with results as received;
-optionally a \sQuote{wide} \code{xts} object with merged data can
-be returned}
+object; currently supported are \sQuote{data.frame} (also the default)
+and \sQuote{data.table}}
 
 \item{tz}{A character variable with the desired local timezone,
 defaulting to the value \sQuote{TZ} environment variable, and

--- a/man/getTicks.Rd
+++ b/man/getTicks.Rd
@@ -41,7 +41,7 @@ Depending on the value of \sQuote{returnAs}, either a
 \sQuote{data.frame} or \sQuote{data.table} object also containing
 non-numerical information such as condition codes, or a time-indexed
 container of type \sQuote{fts}, \sQuote{xts} and \sQuote{zoo} with
-a numeric matrix.
+a numeric matrix containing only \sQuote{value} and \sQuote{size}.
 }
 \description{
 This function uses the Bloomberg API to retrieve ticks for the requested security.


### PR DESCRIPTION
this changes `getMultiTicks()` to only support `data.frame` and `data.table` objects for the return

having `fts` / `xts` / `zoo` here made no sense as we have tick types and cond codes which are not numeric