### PR TITLE
better (optional) data.table export

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-03-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/converters.R (asDataTable): New (unexported) helper function
+	* R/getBars.R (getBars): Use asDataTable()
+	* R/getTicks.R (getBars): Ditto
+ 	* inst/unitTests/runit.getTicks.R (test.getTicksAsDataTable): Adjusted
+
 2017-02-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* NAMESPACE (useDynLib): Add .registration=TRUE; some other edits

--- a/R/converters.R
+++ b/R/converters.R
@@ -1,0 +1,38 @@
+
+##  Copyright (C) 2017         Whit Armstrong and Dirk Eddelbuettel and John Laing
+##
+##  This file is part of Rblpapi
+##
+##  Rblpapi is free software: you can redistribute it and/or modify
+##  it under the terms of the GNU General Public License as published by
+##  the Free Software Foundation, either version 2 of the License, or
+##  (at your option) any later version.
+##
+##  Rblpapi is distributed in the hope that it will be useful,
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##  GNU General Public License for more details.
+##
+##  You should have received a copy of the GNU General Public License
+##  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+## not exported (yet) so no docs (yet)
+asDataTable <- function(res, keepPOSIXct=TRUE) {
+
+    if (!requireNamespace("data.table", quietly=TRUE)) stop("Need data.table to convert", call.=FALSE)
+
+    pt <- time <- `:=` <- NULL		# silly R CMD check warning
+
+    data.table::setNumericRounding(0)   # important to not truncate
+
+    ## we assume res is a matrix with a POSIXct in column one
+    dt <- data.table::data.table(pt=res[,1], 		             # keep POSIXct
+                                 date=data.table::as.IDate(res[,1]), # just Date
+                                 time=data.table::as.ITime(res[,1]), # just Time
+                                 res[, -1])                          # remainder
+    data.table::setkey(dt, pt, date, time)
+
+    if (!keepPOSIXct) dt[, pt := NULL]
+
+    dt
+}

--- a/R/getBars.R
+++ b/R/getBars.R
@@ -1,6 +1,5 @@
 
-##
-##  Copyright (C) 2015 - 2016  Whit Armstrong and Dirk Eddelbuettel and John Laing
+##  Copyright (C) 2015 - 2017  Whit Armstrong and Dirk Eddelbuettel and John Laing
 ##
 ##  This file is part of Rblpapi
 ##
@@ -36,7 +35,7 @@
 ##' desired, defaults to \sQuote{FALSE}
 ##' @param returnAs A character variable describing the type of return
 ##' object; currently supported are \sQuote{matrix} (also the default),
-##' \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}
+##' \sQuote{fts}, \sQuote{xts}, \sQuote{zoo} and \sQuote{data.table}
 ##' @param tz A character variable with the desired local timezone,
 ##' defaulting to the value \sQuote{TZ} environment variable, and
 ##' \sQuote{UTC} if unset
@@ -69,6 +68,7 @@ getBars <- function(security,
                     tz = Sys.getenv("TZ", unset="UTC"),
                     con = defaultConnection()) {
 
+    match.arg(returnAs, c("matrix", "fts", "xts", "zoo", "data.table"))
     if (!inherits(startTime, "POSIXt") || !inherits(endTime, "POSIXt")) {
         stop("startTime and endTime must be Datetime objects", call.=FALSE)
     }
@@ -81,10 +81,11 @@ getBars <- function(security,
     attr(res[,1], "tzone") <- tz
 
     res <- switch(returnAs,
-                  matrix = res,                # default is matrix
-                  fts    = fts::fts(res[,1], res[,-1]),
-                  xts    = xts::xts(res[,-1], order.by=res[,1]),
-                  zoo    = zoo::zoo(res[,-1], order.by=res[,1]),
+                  matrix     = res,                # default is matrix
+                  fts        = fts::fts(res[,1], res[,-1]),
+                  xts        = xts::xts(res[,-1], order.by=res[,1]),
+                  zoo        = zoo::zoo(res[,-1], order.by=res[,1]),
+                  data.table = asDataTable(res),
                   res)                         # fallback is also matrix
     return(res)   # to return visibly
 }

--- a/R/getTicks.R
+++ b/R/getTicks.R
@@ -89,9 +89,7 @@ getTicks <- function(security,
                   fts        = fts::fts(res[,1], res[,-c(1:2,5)]),
                   xts        = xts::xts(res[,-c(1:2,5)], order.by=res[,1]),
                   zoo        = zoo::zoo(res[,-c(1:2,5)], order.by=res[,1]),
-                  data.table = data.table::data.table(date=data.table::as.IDate(res[,1]),
-                                                      time=data.table::as.ITime(res[,1]),
-                                                      res[, -1]),
+                  data.table = asDataTable(res),
                   res)                         # fallback also data.frame
     return(res)   # to return visibly
 
@@ -141,9 +139,7 @@ getMultipleTicks <- function(security,
     attr(res[,1], "tzone") <- tz
 
     if (returnAs == "data.table") {
-        res <- data.table::data.table(date=data.table::as.IDate(res[,1]),
-                                      time=data.table::as.ITime(res[,1]),
-                                      res[, -1])
+        res <- asDataTable(res)
     }
 
     return(res)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,6 +17,7 @@
     \item Minor edits to a few files in order to either please
     \code{R(-devel) CMD check --as-cran}, or update documentation
     \item Adding registration of routines are R 3.4.0 now desires.
+    \item Optional export as \code{data.table} is now more standardized.
   }
 }
 

--- a/inst/unitTests/runit.getTicks.R
+++ b/inst/unitTests/runit.getTicks.R
@@ -73,9 +73,9 @@ if (.runThisTest) {
                   msg = "checking return type")
 
         checkTrue(dim(res)[1] > 10, msg = "check return of at least ten rows")
-        checkTrue(dim(res)[2] == 6, msg = "check return of six columns")
+        checkTrue(dim(res)[2] == 7, msg = "check return of seven columns")
 
-        checkTrue(all(c("date", "time", "type", "value", "size", "condcode") %in% colnames(res)),
+        checkTrue(all(c("pt", "date", "time", "type", "value", "size", "condcode") %in% colnames(res)),
                   msg = "check column names")
     }
 


### PR DESCRIPTION
This adds a first column to data.table exports with the POSIXct -- some plotting etc functions want that.  I also adds date and time as before which makes for good grouping.

So I am suggesting to every-so-slightly change the API, but only in what was already optional.  Good enough?