### PR TITLE
Fix subscribe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.6.2
+Version: 0.3.6.3
 Date: 2017-07-01
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing

--- a/src/subscribe.cpp
+++ b/src/subscribe.cpp
@@ -106,8 +106,7 @@ SEXP eleToDatetime(const Element& e) {
 }
 
 SEXP eleToArray(const Element& e) {
-    if(e.isNull()) { R_NilValue; }
-    SEXP ans;
+    if(e.isNull()) { return R_NilValue; }
     switch(e.datatype()) {
     case BLPAPI_DATATYPE_BOOL:
         return eleToLogical(e);

--- a/src/subscribe.cpp
+++ b/src/subscribe.cpp
@@ -217,9 +217,9 @@ SEXP subscribe_Impl(SEXP con_, std::vector<std::string> securities, std::vector<
                     throw Rcpp::exception("Unknown event type.");
                 }
                 ans["event.type"] = it->second;
-                if(event.eventType() == Event::SUBSCRIPTION_DATA) {
-                    const std::string &topic = *static_cast<const std::string*>(msg.correlationId().asPointer());
-                    ans["topic"] = topic;
+                std::string* sp = static_cast<std::string*>(msg.correlationId().asPointer());
+                if(sp >= &securities[0] && sp < &securities[securities.size()]) {
+                    ans["topic"] = *sp;
                 }
                 ans["data"] = recursiveParse(msg.asElement());
                 // call user function


### PR DESCRIPTION
use index of the securities vector as the CorrelationID, however this change requires unsubscribe to be called upon user interrupt otherwise, we attempt to recycle CorrelationID's upon the next subscription.