### PR TITLE
Need to mark the string returned as UTF-8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.9
+Version: 0.3.8.1
 Date: 2018-01-20
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.8
+Version: 0.3.9
 Date: 2018-01-20
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing

--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -47,7 +47,7 @@ void populateDfRowBDS(SEXP ans, R_len_t row_index, Element& e) {
         LOGICAL(ans)[row_index] = e.getValueAsBool();
         break;
     case BLPAPI_DATATYPE_CHAR:
-        SET_STRING_ELT(ans,row_index,Rf_mkChar(e.getValueAsString()));
+        SET_STRING_ELT(ans,row_index,Rf_mkCharCE(e.getValueAsString(), CE_UTF8));
         break;
     case BLPAPI_DATATYPE_BYTE:
         Rcpp::stop("Unsupported datatype: BLPAPI_DATATYPE_BYTE.");
@@ -70,7 +70,7 @@ void populateDfRowBDS(SEXP ans, R_len_t row_index, Element& e) {
         REAL(ans)[row_index] = e.getValueAsFloat64();
         break;
     case BLPAPI_DATATYPE_STRING:
-        SET_STRING_ELT(ans,row_index,Rf_mkChar(e.getValueAsString()));
+        SET_STRING_ELT(ans,row_index,Rf_mkCharCE(e.getValueAsString(), CE_UTF8));
         break;
     case BLPAPI_DATATYPE_BYTEARRAY:
         Rcpp::stop("Unsupported datatype: BLPAPI_DATATYPE_BYTEARRAY.");
@@ -91,7 +91,7 @@ void populateDfRowBDS(SEXP ans, R_len_t row_index, Element& e) {
         break;
     case BLPAPI_DATATYPE_ENUMERATION:
         //throw std::logic_error("Unsupported datatype: BLPAPI_DATATYPE_ENUMERATION.");
-        SET_STRING_ELT(ans,row_index,Rf_mkChar(e.getValueAsString())); break;
+        SET_STRING_ELT(ans,row_index,Rf_mkCharCE(e.getValueAsString(), CE_UTF8)); break;
     case BLPAPI_DATATYPE_SEQUENCE:
         Rcpp::stop("Unsupported datatype: BLPAPI_DATATYPE_SEQUENCE.");
     case BLPAPI_DATATYPE_CHOICE:

--- a/src/blpapi_utils.cpp
+++ b/src/blpapi_utils.cpp
@@ -242,13 +242,13 @@ void populateDfRow(SEXP ans, R_len_t row_index, const Element& e, RblpapiT rblpa
   case RblpapiT::Datetime:
     REAL(ans)[row_index] = bbgDateToPOSIX(e.getValueAsDatetime()); break;
   case RblpapiT::String:
-    SET_STRING_ELT(ans,row_index,Rf_mkChar(e.getValueAsString())); break;
+    SET_STRING_ELT(ans,row_index,Rf_mkCharCE(e.getValueAsString(), CE_UTF8)); break;
   default: // try to convert it as a string
-    SET_STRING_ELT(ans,row_index,Rf_mkChar(e.getValueAsString())); break;
+    SET_STRING_ELT(ans,row_index,Rf_mkCharCE(e.getValueAsString(), CE_UTF8)); break;
   }
 }
 
-Rcpp::NumericVector createPOSIXtVector(const std::vector<double> & ticks, 
+Rcpp::NumericVector createPOSIXtVector(const std::vector<double> & ticks,
                                        const std::string tz) {
     Rcpp::NumericVector pt(ticks.begin(), ticks.end());
     pt.attr("class") = Rcpp::CharacterVector::create("POSIXct", "POSIXt");

--- a/src/getFieldInfo.cpp
+++ b/src/getFieldInfo.cpp
@@ -39,10 +39,10 @@ Rcpp::List fieldInfo_Impl(SEXP con_, std::vector<std::string> fields) {
   Rcpp::List res(allocateDataFrame(fields, colnames, res_types));
   R_len_t i(0);
   for(auto f : fldinfos) {
-    SET_STRING_ELT(res[0],i,Rf_mkChar(f.id.c_str()));
-    SET_STRING_ELT(res[1],i,Rf_mkChar(f.mnemonic.c_str()));
-    SET_STRING_ELT(res[2],i,Rf_mkChar(f.datatype.c_str()));
-    SET_STRING_ELT(res[3],i,Rf_mkChar(f.ftype.c_str()));
+    SET_STRING_ELT(res[0],i,Rf_mkCharCE(f.id.c_str(), CE_UTF8));
+    SET_STRING_ELT(res[1],i,Rf_mkCharCE(f.mnemonic.c_str(), CE_UTF8));
+    SET_STRING_ELT(res[2],i,Rf_mkCharCE(f.datatype.c_str(), CE_UTF8));
+    SET_STRING_ELT(res[3],i,Rf_mkCharCE(f.ftype.c_str(), CE_UTF8));
     ++i;
   }
   return res;


### PR DESCRIPTION
Hi @eddelbuettel , first of all, thanks for making this great package. 

Occasionally, we need to return non-English characters from Bloomberg (as the example below). However, because the current version doesn't mark the encoding as UTF8 explicitly, it causes trouble on a Windows machine, where the native encoding varies.

This PR will fix this. I have manually compiled the PR version and tested it on the Bloomberg computer in the office and find no problems by far. 

If there's more need to be done, please let me know.

Thanks.

### Example

```r
library(Rblpapi)
blpConnect()
out <- bdp(securities = c("BBG006YQMFQ5", "BBG005CMJQ71"),
           fields = c("NAME_CHINESE_SIMPLIFIED", "ISSUE_DT"),
           overrides = c("SECURITY_NAME_LANG" = "10"))
Encoding(out$NAME_CHINESE_SIMPLIFIED)
# before this PR, it says "unknown" and it causes trouble, because we have 
# to change the encoding by hand like `Encoding(out$NAME_CHINESE_SIMPLIFIED) <- "UTF-8"`
# in order to display the strings correctly.
out$ISSUE_DT
out$NAME_CHINESE_SIMPLIFIED
```