### PR TITLE
initialize DateVector() with NAs

### DIFF
--- a/inst/unitTests/runit.bdp.R
+++ b/inst/unitTests/runit.bdp.R
@@ -42,4 +42,9 @@ if (.runThisTest) {
                   msg="check column classes match fieldInfo")
     }
 
+    test.naDate <- function() {
+        res <- bdp("BBG006YQMFQ5", "ISSUE_DT")
+        checkTrue(is.na(res$ISSUE_DT), msg="checking NA date value")
+    }
+
 }

--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -132,7 +132,8 @@ SEXP allocateDataFrameColumn(int fieldT, size_t n) {
         Rcpp::stop("Unsupported datatype: BLPAPI_DATATYPE_BYTEARRAY.");
         break;
     case BLPAPI_DATATYPE_DATE:
-        ans = Rcpp::DateVector(n);
+        ans = Rcpp::NumericVector(n, NA_REAL);
+        ans = Rcpp::DateVector(ans);
         break;
     case BLPAPI_DATATYPE_TIME:
         //FIXME: separate out time later

--- a/src/blpapi_utils.cpp
+++ b/src/blpapi_utils.cpp
@@ -328,7 +328,8 @@ SEXP allocateDataFrameColumn(RblpapiT rblpapitype, const size_t n) {
         ans = Rcpp::NumericVector(n, NA_REAL);
         break;
     case RblpapiT::Date:
-        ans = Rcpp::DateVector(n);
+        ans = Rcpp::NumericVector(n, NA_REAL);
+        ans = Rcpp::DateVector(ans);
         break;
     case RblpapiT::Datetime:
         // FIXME: string for datetime ?


### PR DESCRIPTION
Fix a bug introduced by PR #273 

See the comments in PR #278 

```r
library(Rblpapi)
blpConnect()
out <- bdp(securities = c("BBG006YQMFQ5", "BBG005CMJQ71"),
           fields = c("ISSUE_DT"))

out$ISSUE_DT
# before this PR, it returns 1970-01-01
# after this PR, it returns NA as before (the CRAN version)
```
