### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ spx_ndx <- bdh(securities = c("SPX Index","NDX Index"),
                start.date = as.Date("2013-03-01"), 
                include.non.trading.days = TRUE)
 
-monthlyOptions <- structure(c("ACTUAL", "MONTHLY"),
+monthly.options <- structure(c("ACTUAL", "MONTHLY"),
                             names = c("periodicityAdjustment",
                                       "periodicitySelection"))
 spx_ndx_monthly <- bdh(securities = c("SPX Index","NDX Index"), 


### PR DESCRIPTION
Before the fix, computing `spx_ndx_monthly` would raise:

```
Error in bdh_Impl(con, securities, fields, start.date, end.date, options, : object 'monthly.options' not found
```