### PR TITLE
Minor change to doc of bds - result is a data.frame

### DIFF
--- a/R/bds.R
+++ b/R/bds.R
@@ -39,7 +39,7 @@
 ##' @param con A connection object as created by a \code{blpConnect}
 ##' call, and retrieved via the internal function
 ##' \code{defaultConnection}.
-##' @return A data.frame with one row per observation.
+##' @return A data frame object with the requested data set.
 ##' @author Whit Armstrong and Dirk Eddelbuettel
 ##' @examples
 ##' \dontrun{

--- a/R/bds.R
+++ b/R/bds.R
@@ -56,10 +56,6 @@ bds <- function(security, field, options=NULL,
         stop("more than one security submitted.", call.=FALSE)
     if (length(field) != 1L)
         stop("more than one field submitted.", call.=FALSE)
-    res <- bds_Impl(con, security, field, options, overrides, verbose, identity)
-    if (typeof(res)=="list" && length(res)==1) {
-        res <- res[[1]]
-    }
-    res
+    bds_Impl(con, security, field, options, overrides, verbose, identity)
 }
 

--- a/R/bds.R
+++ b/R/bds.R
@@ -39,11 +39,7 @@
 ##' @param con A connection object as created by a \code{blpConnect}
 ##' call, and retrieved via the internal function
 ##' \code{defaultConnection}.
-##' @return A list with as many entries as there are entries in
-##' \code{securities}; each list contains a data.frame with one row
-##' per observations and as many columns as entries in
-##' \code{fields}. If the list is of length one, it is collapsed into
-##' a single data frame.
+##' @return A data.frame with one row per observation.
 ##' @author Whit Armstrong and Dirk Eddelbuettel
 ##' @examples
 ##' \dontrun{

--- a/man/bds.Rd
+++ b/man/bds.Rd
@@ -33,11 +33,7 @@ call, and retrieved via the internal function
 \code{defaultConnection}.}
 }
 \value{
-A list with as many entries as there are entries in
-\code{securities}; each list contains a data.frame with one row
-per observations and as many columns as entries in
-\code{fields}. If the list is of length one, it is collapsed into
-a single data frame.
+A data frame object with the requested data set.
 }
 \description{
 This function uses the Bloomberg API to retrieve 'bds' (Bloomberg


### PR DESCRIPTION
As function `bds` accepts only one security and one field, the result should always be a single data.frame