### PR TITLE
switch vignette to the minidown water framework (closes: #329)

### DIFF
--- a/vignettes/rblpapi-intro.Rmd
+++ b/vignettes/rblpapi-intro.Rmd
@@ -2,11 +2,15 @@
 title: "Introducing Rblpapi"
 author: "Dirk Eddelbuettel"
 date: "2015-08-13"
-output: rmarkdown::html_vignette
+output:
+  minidown::mini_document:
+    framework: water
+    toc: true
+    toc_float: true
 vignette: >
   %\VignetteIndexEntry{Introducing Rblpapi}
   %\VignetteEngine{knitr::rmarkdown}
-  \usepackage[utf8]{inputenc}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ## Introduction


### PR DESCRIPTION
This very simple PR switches the vignette to the very lightweight yet very legible 'water' CSS framework via `minidown`.