### PR TITLE
New release 0.3.11 (closes: #328)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2021-04-18  Dirk Eddelbuettel  <edd@debian.org>
+2021-04-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): New release 0.3.11
 
@@ -7,6 +7,11 @@
 	* R/subscribe.R: Update two URLs to https
 	* man/subscribe.Rd: Ditto
 	* README.md: Ditto
+
+2021-04-19  John Laing  <john.laing@gmail.com>
+
+	* man/bds.Rd: Regenerate based on updated roxygen
+	* R/bds.R: Simply given single argument
 
 2021-04-17  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -28,6 +33,10 @@
 	* .Rbuildignore: Add .github
 
 	* .travis.yml: Switch to bionic and use run.sh from r-ci
+
+2021-02-25  Michael Kerber  <kerber@tugraz.at>
+
+	* man/bds.Rd: Correct return type desription
 
 2020-05-19  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -36,7 +36,7 @@
 
 	* .travis.yml: Switch to bionic and use run.sh from r-ci
 
-2021-02-25  Michael Kerber  <kerber@tugraz.at>
+2021-02-25  Michael Kerber  <mtkerber@gmail.com>
 
 	* man/bds.Rd: Correct return type desription
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2021-04-18  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): New release 0.3.11
+
+	* DESCRIPTION (Suggests): Add rmarkdown
+
+	* R/subscribe.R: Update two URLs to https
+	* man/subscribe.Rd: Ditto
+	* README.md: Ditto
+
+2021-04-17  Dirk Eddelbuettel  <edd@debian.org>
+
+	* tests/tinytest.R: Renamed and converted from doRUnit.R
+	* inst/tinytest/*: Renamed and converted from RUnit to testthat
+	* DESCRIPTION (Suggests): Switched from RUnit to tinytest
+
+	* vignettes/rblpapi-intro.Rmd: Switched to minidown
+	* DESCRIPTION (Suggests): Added minidown
+
 2021-03-17  Dirk Eddelbuettel  <edd@debian.org>
 
 	* configure: Change from bash to sh

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,16 +2,18 @@
 
 	* DESCRIPTION (Version, Date): New release 0.3.11
 
+2021-04-19  John Laing  <john.laing@gmail.com>
+
+	* man/bds.Rd: Regenerate based on updated roxygen
+	* R/bds.R: Simply given single argument
+
+2021-04-18  Dirk Eddelbuettel  <edd@debian.org>
+
 	* DESCRIPTION (Suggests): Add rmarkdown
 
 	* R/subscribe.R: Update two URLs to https
 	* man/subscribe.Rd: Ditto
 	* README.md: Ditto
-
-2021-04-19  John Laing  <john.laing@gmail.com>
-
-	* man/bds.Rd: Regenerate based on updated roxygen
-	* R/bds.R: Simply given single argument
 
 2021-04-17  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
 Version: 0.3.11
-Date: 2021-04-18
+Date: 2021-04-20
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.10
-Date: 2019-04-02
+Version: 0.3.11
+Date: 2021-04-18
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils
-Suggests: fts, xts, zoo, data.table, knitr, minidown, tinytest
+Suggests: fts, xts, zoo, data.table, knitr, rmarkdown, minidown, tinytest
 VignetteBuilder: knitr
 LazyLoad: yes
 StagedInstall: no

--- a/R/subscribe.R
+++ b/R/subscribe.R
@@ -27,7 +27,7 @@
 ##'
 ##' Full detials of the subscription string can be found in the header
 ##' file
-##' \href{http://bloomberg.github.io/blpapi-docs/cpp/3.8/blpapi__subscriptionlist_8h.html}{blpapi_subscriptionlist.h}.
+##' \href{https://bloomberg.github.io/blpapi-docs/cpp/3.8/blpapi__subscriptionlist_8h.html}{blpapi_subscriptionlist.h}.
 ##' 
 ##' @param securities A character vector with security symbols in
 ##' Bloomberg notation.
@@ -43,7 +43,7 @@
 ##' call, and retrieved via the internal function
 ##' \code{defaultConnection}.
 ##' @return This function always returns NULL.
-##' @references \url{http://bloomberg.github.io/blpapi-docs/cpp/3.8}
+##' @references \url{https://bloomberg.github.io/blpapi-docs/cpp/3.8/}
 ##' @author Whit Armstrong
 ##' @examples
 ##' \dontrun{

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![LibraryLicense](https://img.shields.io/badge/license-License.txt-yellow.svg?style=flat)](https://raw.githubusercontent.com/Rblp/Rblpapi/master/inst/License.txt) 
 [![CRAN](http://www.r-pkg.org/badges/version/Rblpapi)](https://cran.r-project.org/package=Rblpapi) 
 [![Dependencies](https://tinyverse.netlify.com/badge/Rblpapi)](https://cran.r-project.org/package=Rblpapi) 
-[![Downloads](http://cranlogs.r-pkg.org/badges/Rblpapi?color=brightgreen)](http://www.r-pkg.org/pkg/Rblpapi)
+[![Downloads](http://cranlogs.r-pkg.org/badges/Rblpapi?color=brightgreen)](https://www.r-pkg.org:443/pkg/Rblpapi)
 [![Last Commit](https://img.shields.io/github/last-commit/Rblp/Rblpapi)](https://github.com/Rblp/Rblpapi)
 
 ### Background
@@ -67,7 +67,7 @@ install.packages("Rblpapi")
 ```
 
 Interim (source or binary) releases _may_ be also be made available through the
-[ghrr drat](http://ghrr.github.io/drat) repository as well and can be accessed via
+[ghrr drat](https://ghrr.github.io/drat/) repository as well and can be accessed via
 
 ```r
 install.packages("drat")       # easier repo access + creation

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,7 +4,7 @@
 \newcommand{\ghpr}{\href{https://github.com/Rblp/Rblpapi/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/Rblp/Rblpapi/issues/#1}{##1}}
 
-\section{Changes in Rblpapi version 0.3.11 (2021-04-18)}{
+\section{Changes in Rblpapi version 0.3.11 (2021-04-20)}{
   \itemize{
     \item Support blpAutoAuthenticate and B-PIPE access, refactor and
     generalise authentication (James Bell in \ghpr{285})

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,6 +4,19 @@
 \newcommand{\ghpr}{\href{https://github.com/Rblp/Rblpapi/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/Rblp/Rblpapi/issues/#1}{##1}}
 
+\section{Changes in Rblpapi version 0.3.11 (2021-04-18)}{
+  \itemize{
+    \item Support blpAutoAuthenticate and B-PIPE access, refactor and
+    generalise authentication (James Bell in \ghpr{285})
+    \item Deprecate \code{excludeterm} (John in \ghpr{306})
+    \item Correct example in README.md (Maxime Legrand in \ghpr{314})
+    \item Add GitHub Actions continuous integration (Dirk in \ghpr{323})
+    \item Remove bashisms detected by R CMD check (Dirk \ghpr{324})
+    \item Switch vignette to minidown (Dirk in \ghpr{331})
+    \item Switch unit tests framework to tinytest (Dirk in \ghpr{332})
+  }
+}
+
 \section{Changes in Rblpapi version 0.3.10 (2019-04-02)}{
   \itemize{
     \item The \code{start.date} format for \code{bdh} now allows character

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,6 +10,8 @@
     generalise authentication (James Bell in \ghpr{285})
     \item Deprecate \code{excludeterm} (John in \ghpr{306})
     \item Correct example in README.md (Maxime Legrand in \ghpr{314})
+    \item Correct \code{bds} man page (and code) (Michael Kerber, and
+    John, in \ghpr{320})
     \item Add GitHub Actions continuous integration (Dirk in \ghpr{323})
     \item Remove bashisms detected by R CMD check (Dirk \ghpr{324})
     \item Switch vignette to minidown (Dirk in \ghpr{331})

--- a/man/subscribe.Rd
+++ b/man/subscribe.Rd
@@ -39,7 +39,7 @@ quotes.
 
 Full detials of the subscription string can be found in the header
 file
-\href{http://bloomberg.github.io/blpapi-docs/cpp/3.8/blpapi__subscriptionlist_8h.html}{blpapi_subscriptionlist.h}.
+\href{https://bloomberg.github.io/blpapi-docs/cpp/3.8/blpapi__subscriptionlist_8h.html}{blpapi_subscriptionlist.h}.
 }
 \examples{
 \dontrun{
@@ -49,7 +49,7 @@ file
 }
 }
 \references{
-\url{http://bloomberg.github.io/blpapi-docs/cpp/3.8}
+\url{https://bloomberg.github.io/blpapi-docs/cpp/3.8/}
 }
 \author{
 Whit Armstrong


### PR DESCRIPTION
This PR finalises the changes for a new release to address #328, and finishes up the work in PRs #331 and #332 by updating the NEWS.Rd and ChangeLog files.  Otherwise the only other check is a another `R CMD check` warning on outdated http URLs which is fixed in the README.md and one manual page.

This could probably get shipped as is, but give that @johnlaing  found one minor blunder each in the two preceding PRs I may as well procede slowly :)