### PR TITLE
returnAs=... support for bdh (closes #206) (rebased)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-04-24  Michael Kerber  <mtkerber@gmail.com>
+
+	* man/bdh.R: Support new argument 'returnAs'
+
 2021-04-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): New release 0.3.11

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-04-24  Dirk Eddelbuettel  <edd@debian.org>
+
+	* man/bdh.Rd: Regenerated
+
 2021-04-24  Michael Kerber  <mtkerber@gmail.com>
 
 	* man/bdh.R: Support new argument 'returnAs'

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,14 @@
+2021-04-27  John Laing  <john.laing@gmail.com>
+
+	* inst/tinytest/test_bdh.R: Added tests for new argument 'returnAs'
+
 2021-04-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* man/bdh.Rd: Regenerated
 
 2021-04-24  Michael Kerber  <mtkerber@gmail.com>
 
-	* man/bdh.R: Support new argument 'returnAs'
+	* R/bdh.R: Support new argument 'returnAs'
 
 2021-04-20  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/R/bdh.R
+++ b/R/bdh.R
@@ -38,8 +38,11 @@
 ##' being set) as well as a value.
 ##' @param verbose A boolean indicating whether verbose operation is
 ##' desired, defaults to \sQuote{FALSE}
+##' @param returnAs A character variable describing the type of return
+##' object; currently supported are \sQuote{data.frame} (also the default),
+##' \sQuote{data.table}, \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}
 ##' @param identity An optional identity object as created by a
-##' \code{blpAuthenticate} call, and retrived via the internal function
+##' \code{blpAuthenticate} call, and retrieved via the internal function
 ##' \code{defaultAuthentication}.
 ##' @param con A connection object as created by a \code{blpConnect}
 ##' call, and retrieved via the internal function
@@ -48,10 +51,10 @@
 ##' be retrieved as doubles instead. This option is a workaround for very
 ##' large values which would overflow int32. Defaults to \sQuote{FALSE}
 ##' @return A list with as a many entries as there are entries in
-##' \code{securities}; each list contains a data.frame with one row
+##' \code{securities}; each list contains a object of class \code{returnAs} with one row
 ##' per observations and as many columns as entries in
 ##' \code{fields}. If the list is of length one, it is collapsed into
-##' a single data frame. Note that the order of securities returned
+##' a single object of class \code{returnAs}. Note that the order of securities returned
 ##' is determined by the backend and may be different from the order
 ##' of securities in the \code{securities} field.
 ##' @seealso For historical futures series, see \sQuote{DOCS #2072138 <GO>}
@@ -73,7 +76,7 @@
 ##'       start.date="-6CM", options=opt)
 ##'
 ##'   ## example for options and overrides
-##'   opt <- c("periodicitySelection" = "QUARTERLY")
+##'   opt <- c("periodicitySelection"="QUARTERLY")
 ##'   ovrd <- c("BEST_FPERIOD_OVERRIDE"="1GQ")
 ##'   bdh("IBM US Equity", "BEST_SALES", start.date=Sys.Date()-365.25*4,
 ##'       options=opt, overrides=ovrd)
@@ -84,8 +87,10 @@
 ##' }
 bdh <- function(securities, fields, start.date, end.date=NULL,
                 include.non.trading.days=FALSE, options=NULL, overrides=NULL,
-                verbose=FALSE, identity=defaultAuthentication(), con=defaultConnection(),
+                verbose=FALSE, returnAs=getOption("bdhType", "data.frame"), 
+                identity=defaultAuthentication(), con=defaultConnection(),
                 int.as.double=getOption("blpIntAsDouble", FALSE)) {
+    match.arg(returnAs, c("data.frame", "fts", "xts", "zoo", "data.table"))
     if (class(start.date) == "Date") {
         start.date <- format(start.date, format="%Y%m%d")
     }
@@ -101,7 +106,16 @@ bdh <- function(securities, fields, start.date, end.date=NULL,
 
     res <- bdh_Impl(con, securities, fields, start.date, end.date, options, overrides,
                     verbose, identity, int.as.double)
-    if (typeof(res)=="list" && length(res)==1) {
+    
+    res <- switch(returnAs,
+                  data.frame = res,            # default is data.frame
+                  fts        = lapply(res, function(x) fts::fts(x[,1], x[,-1])),
+                  xts        = lapply(res, function(x) xts::xts(x[,-1], order.by = x[,1])),
+                  zoo        = lapply(res, function(x) zoo::zoo(x[,-1], order.by = x[,1])),
+                  data.table = lapply(res, function(x) Rblpapi:::asDataTable(x)[,-c(1,3)]),
+                  res)
+  
+  if (typeof(res)=="list" && length(res)==1) {
         res <- res[[1]]
     }
     res

--- a/R/bdh.R
+++ b/R/bdh.R
@@ -51,10 +51,10 @@
 ##' be retrieved as doubles instead. This option is a workaround for very
 ##' large values which would overflow int32. Defaults to \sQuote{FALSE}
 ##' @return A list with as a many entries as there are entries in
-##' \code{securities}; each list contains a object of class \code{returnAs} with one row
+##' \code{securities}; each list contains a object of type \code{returnAs} with one row
 ##' per observations and as many columns as entries in
 ##' \code{fields}. If the list is of length one, it is collapsed into
-##' a single object of class \code{returnAs}. Note that the order of securities returned
+##' a single object of type \code{returnAs}. Note that the order of securities returned
 ##' is determined by the backend and may be different from the order
 ##' of securities in the \code{securities} field.
 ##' @seealso For historical futures series, see \sQuote{DOCS #2072138 <GO>}
@@ -109,10 +109,10 @@ bdh <- function(securities, fields, start.date, end.date=NULL,
     
     res <- switch(returnAs,
                   data.frame = res,            # default is data.frame
-                  fts        = lapply(res, function(x) fts::fts(x[,1], x[,-1])),
-                  xts        = lapply(res, function(x) xts::xts(x[,-1], order.by = x[,1])),
-                  zoo        = lapply(res, function(x) zoo::zoo(x[,-1], order.by = x[,1])),
-                  data.table = lapply(res, function(x) Rblpapi:::asDataTable(x)[,-c(1,3)]),
+                  fts        = lapply(res, function(x) fts::fts(x[,1], x[,-1, drop = FALSE])),
+                  xts        = lapply(res, function(x) xts::xts(x[,-1, drop = FALSE], order.by = x[,1])),
+                  zoo        = lapply(res, function(x) zoo::zoo(x[,-1, drop = FALSE], order.by = x[,1])),
+                  data.table = lapply(res, function(x) data.table::data.table(date = data.table::as.IDate(x[, 1]), x[, -1, drop = FALSE])),
                   res)
   
   if (typeof(res)=="list" && length(res)==1) {

--- a/inst/tinytest/test_bdh.R
+++ b/inst/tinytest/test_bdh.R
@@ -31,6 +31,24 @@ expect_true(dim(res)[2] == 4, info = "check return of four cols")
 expect_true(all(c("PX_LAST","OPEN_INT","FUT_CUR_GEN_TICKER") %in% colnames(res)), info = "check column names")
 #}
 
+#test.bdhReturnAsDT <- function() {
+res <- bdh("TY1 Comdty",c("PX_LAST","OPEN_INT","FUT_CUR_GEN_TICKER"),Sys.Date()-10,returnAs="data.table")
+expect_true(inherits(res, "data.table"), info = "checking return type - data.table")
+expect_true(dim(res)[1] >= 5, info = "check return of five rows - data.table")
+expect_true(dim(res)[2] == 4, info = "check return of four cols - data.table")
+expect_true(all(c("PX_LAST","OPEN_INT","FUT_CUR_GEN_TICKER") %in% colnames(res)), info = "check column names - data.table")
+#}
+
+#test.bdhReturnAsTS <- function() {
+for (retAs in c("fts", "xts", "zoo")) {
+    res <- bdh("TY1 Comdty",c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_CLOSE"),Sys.Date()-10,returnAs=retAs)
+    expect_true(inherits(res, retAs), info = paste("checking return type -", retAs))
+    expect_true(dim(res)[1] >= 5, info = paste("check return of five rows -", retAs))
+    expect_true(dim(res)[2] == 4, info = paste("check return of four cols -", retAs))
+    expect_true(all(c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_CLOSE") %in% colnames(res)), info = paste("check column names -", retAs))
+}
+#}
+
 #    test.bdhDateAsDouble <- function() {
 res <- bdh("DOENUSCH Index","ECO_RELEASE_DT",start.date=as.Date('2016-02-01'),end.date=as.Date('2016-02-29'))
 expect_true(inherits(res, "data.frame"), info = "checking return type")

--- a/man/bdh.Rd
+++ b/man/bdh.Rd
@@ -6,9 +6,9 @@
 \usage{
 bdh(securities, fields, start.date, end.date = NULL,
   include.non.trading.days = FALSE, options = NULL, overrides = NULL,
-  verbose = FALSE, identity = defaultAuthentication(),
-  con = defaultConnection(), int.as.double = getOption("blpIntAsDouble",
-  FALSE))
+  verbose = FALSE, returnAs = getOption("bdhType", "data.frame"),
+  identity = defaultAuthentication(), con = defaultConnection(),
+  int.as.double = getOption("blpIntAsDouble", FALSE))
 }
 \arguments{
 \item{securities}{A character vector with security symbols in
@@ -35,8 +35,12 @@ being set) as well as a value.}
 \item{verbose}{A boolean indicating whether verbose operation is
 desired, defaults to \sQuote{FALSE}}
 
+\item{returnAs}{A character variable describing the type of return
+object; currently supported are \sQuote{data.frame} (also the default),
+\sQuote{data.table}, \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}}
+
 \item{identity}{An optional identity object as created by a
-\code{blpAuthenticate} call, and retrived via the internal function
+\code{blpAuthenticate} call, and retrieved via the internal function
 \code{defaultAuthentication}.}
 
 \item{con}{A connection object as created by a \code{blpConnect}
@@ -49,10 +53,10 @@ large values which would overflow int32. Defaults to \sQuote{FALSE}}
 }
 \value{
 A list with as a many entries as there are entries in
-\code{securities}; each list contains a data.frame with one row
+\code{securities}; each list contains a object of type \code{returnAs} with one row
 per observations and as many columns as entries in
 \code{fields}. If the list is of length one, it is collapsed into
-a single data frame. Note that the order of securities returned
+a single object of type \code{returnAs}. Note that the order of securities returned
 is determined by the backend and may be different from the order
 of securities in the \code{securities} field.
 }
@@ -76,7 +80,7 @@ Data History) queries
       start.date="-6CM", options=opt)
 
   ## example for options and overrides
-  opt <- c("periodicitySelection" = "QUARTERLY")
+  opt <- c("periodicitySelection"="QUARTERLY")
   ovrd <- c("BEST_FPERIOD_OVERRIDE"="1GQ")
   bdh("IBM US Equity", "BEST_SALES", start.date=Sys.Date()-365.25*4,
       options=opt, overrides=ovrd)


### PR DESCRIPTION
This picks up the nice work by @mtkerbeR in #334 but places it cleanly off the head of our repo.  It also add a ChangeLog entry and updated the Rd page.

Original motivation from #334 follows.

A first proposal of minor changes to code for function `bdh()` to return different types of objects - analogously to `getTicks()`

As this is one of my first contributions in R, please let me know about feedback/weaknesses of the proposed solutions, which I would be happy to take care of:

Two points worth mentioning:

1. a new Option `bdhType` is introduced, to allow for backward-compatibility.  Alternative would be to use `blpType` here as in getBars, however, if this value is set to a format which is not supported in bdh (like `matrix`, which is feasible in `getBars`) existing code might break. This could be catched by extending possible values in `match.arg(returnAs, c("data.frame", "fts", "xts", "zoo", "data.table"))` by `getOption("blpType")`, which would later on leads to a data.frame via the fallback option in switch if format is not supported.

1. If some columns are non-numeric, types inheriting from zoo will convert numbers to characters for all columns (due to inheritance from `matrix`)

The code could be (unit)tested as follows - adapting existing test cases for bdh to the case of different values for parameter `returnAs`:

```
sec <- "TY1 Comdty"      
fields <- c("PX_LAST","OPEN_INT","FUT_CUR_GEN_TICKER") # probably also worth testing with fields of length 1, due to drop = FALSE
retAs <- c("data.frame", "fts", "xts", "zoo", "data.table")

res <- lapply(type, function(x) bdh(sec, fields, Sys.Date()-10, returnAs=x))

expect_true(all(sapply(seq_along(retAs), function(x) inherits(res[[x]], retAs[x]))), info = "checking return type")
expect_true(all(sapply(res, nrow) >= 5), info = "check return of five rows")
expect_true(all(sapply(res[sapply(res, function(x) !inherits(x, "zoo"))], ncol)==length(fields)+1), info = "check return of four columns for non-time series")
expect_true(all(sapply(res[sapply(res, function(x)  inherits(x, "zoo"))], ncol)==length(fields)),   info = "check return of four columns for time series")
expect_true(all(sapply(res, function(x) tail(colnames(x), length(fields)) == fields)), info = "check column names")
```
