### PR TITLE
Refine test and roll version to 0.3.11.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-04-28  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_bdh.R: Tweak thanks to hint from Michael
+
 2021-04-27  John Laing  <john.laing@gmail.com>
 
 	* inst/tinytest/test_bdh.R: Added tests for new argument 'returnAs'

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2021-04-28  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version,Date): Roll version and date
+
 	* inst/tinytest/test_bdh.R: Tweak thanks to hint from Michael
 
 2021-04-27  John Laing  <john.laing@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.11
-Date: 2021-04-20
+Version: 0.3.11.1
+Date: 2021-04-28
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils

--- a/inst/tinytest/test_bdh.R
+++ b/inst/tinytest/test_bdh.R
@@ -41,11 +41,11 @@ expect_true(all(c("PX_LAST","OPEN_INT","FUT_CUR_GEN_TICKER") %in% colnames(res))
 
 #test.bdhReturnAsTS <- function() {
 for (retAs in c("fts", "xts", "zoo")) {
-    res <- bdh("TY1 Comdty",c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_CLOSE"),Sys.Date()-10,returnAs=retAs)
+    res <- bdh("TY1 Comdty",c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_LAST"),Sys.Date()-10,returnAs=retAs)
     expect_true(inherits(res, retAs), info = paste("checking return type -", retAs))
     expect_true(dim(res)[1] >= 5, info = paste("check return of five rows -", retAs))
     expect_true(dim(res)[2] == 4, info = paste("check return of four cols -", retAs))
-    expect_true(all(c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_CLOSE") %in% colnames(res)), info = paste("check column names -", retAs))
+    expect_true(all(c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_LAST") %in% colnames(res)), info = paste("check column names -", retAs))
 }
 #}
 


### PR DESCRIPTION
This adds the test refinement suggested by @mtkerbeR (whom I can't formally invite to code review, please just glance and nod if you have a minute) and rolls the version to mark it as distinct from the recent CRAN release.  