### PR TITLE
Remove the extra ` to balance chunk delimiters

### DIFF
--- a/vignettes/rblpapi-intro.Rmd
+++ b/vignettes/rblpapi-intro.Rmd
@@ -38,7 +38,7 @@ Use
 
 ```{r, eval=FALSE}
 library(Rblpapi)
-````
+```
 
 to load the package.  You can also set options which will
 automatically connect at package load; see the next section.


### PR DESCRIPTION
FYI unbalanced chunk delimiters will no longer be allowed in the future (https://github.com/yihui/knitr/issues/2057). Thanks!