### PR TITLE
Debug BDS segfault #253

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,6 +17,10 @@ bds_Impl <- function(con_, securities, field, options_, overrides_, verbose, ide
     .Call(`_Rblpapi_bds_Impl`, con_, securities, field, options_, overrides_, verbose, identity_)
 }
 
+bds_Impl_Debug <- function(con_, securities, field, options_, overrides_, repeats, verbose, identity_) {
+    .Call(`_Rblpapi_bds_Impl_Debug`, con_, securities, field, options_, overrides_, repeats, verbose, identity_)
+}
+
 getPortfolio_Impl <- function(con_, securities, field, options_, overrides_, verbose, identity_) {
     .Call(`_Rblpapi_getPortfolio_Impl`, con_, securities, field, options_, overrides_, verbose, identity_)
 }

--- a/R/bds.R
+++ b/R/bds.R
@@ -59,3 +59,14 @@ bds <- function(security, field, options=NULL,
     bds_Impl(con, security, field, options, overrides, verbose, identity)
 }
 
+
+bds_debug <- function(security, field, options=NULL,
+                overrides=NULL, repeats = 1, verbose=FALSE,
+                identity=defaultAuthentication(), con=defaultConnection()) {
+    if (length(security) != 1L)
+        stop("more than one security submitted.", call.=FALSE)
+    if (length(field) != 1L)
+        stop("more than one field submitted.", call.=FALSE)
+    bds_Impl_Debug(con, security, field, options, overrides, repeats, verbose, identity)
+}
+

--- a/inst/tinytest/test_segfault.R
+++ b/inst/tinytest/test_segfault.R
@@ -1,0 +1,9 @@
+
+library(Rblpapi)
+
+blpConnect()
+
+res <- Rblpapi:::bds_debug("YCSW0303 Index", "par_curve", repeats = 10000)
+
+print("no segfault")
+print(length(res))

--- a/src/Rblpapi_types.h
+++ b/src/Rblpapi_types.h
@@ -22,8 +22,8 @@
 #include <string>
 #include <Rcpp.h>
 
-typedef std::map<std::string,SEXP> LazyFrameT;
-typedef std::map<std::string,SEXP>::iterator LazyFrameIteratorT;
+typedef std::map<std::string,Rcpp::RObject> LazyFrameT;
+typedef std::map<std::string,Rcpp::RObject>::iterator LazyFrameIteratorT;
 
 class FieldInfo {
 public:

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -73,6 +73,24 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// bds_Impl_Debug
+Rcpp::List bds_Impl_Debug(SEXP con_, std::vector<std::string> securities, std::string field, SEXP options_, SEXP overrides_, int repeats, bool verbose, SEXP identity_);
+RcppExport SEXP _Rblpapi_bds_Impl_Debug(SEXP con_SEXP, SEXP securitiesSEXP, SEXP fieldSEXP, SEXP options_SEXP, SEXP overrides_SEXP, SEXP repeatsSEXP, SEXP verboseSEXP, SEXP identity_SEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type con_(con_SEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type securities(securitiesSEXP);
+    Rcpp::traits::input_parameter< std::string >::type field(fieldSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type options_(options_SEXP);
+    Rcpp::traits::input_parameter< SEXP >::type overrides_(overrides_SEXP);
+    Rcpp::traits::input_parameter< int >::type repeats(repeatsSEXP);
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type identity_(identity_SEXP);
+    rcpp_result_gen = Rcpp::wrap(bds_Impl_Debug(con_, securities, field, options_, overrides_, repeats, verbose, identity_));
+    return rcpp_result_gen;
+END_RCPP
+}
 // getPortfolio_Impl
 Rcpp::List getPortfolio_Impl(SEXP con_, std::vector<std::string> securities, std::string field, SEXP options_, SEXP overrides_, bool verbose, SEXP identity_);
 RcppExport SEXP _Rblpapi_getPortfolio_Impl(SEXP con_SEXP, SEXP securitiesSEXP, SEXP fieldSEXP, SEXP options_SEXP, SEXP overrides_SEXP, SEXP verboseSEXP, SEXP identity_SEXP) {
@@ -251,6 +269,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_Rblpapi_bdh_Impl", (DL_FUNC) &_Rblpapi_bdh_Impl, 10},
     {"_Rblpapi_bdp_Impl", (DL_FUNC) &_Rblpapi_bdp_Impl, 7},
     {"_Rblpapi_bds_Impl", (DL_FUNC) &_Rblpapi_bds_Impl, 7},
+    {"_Rblpapi_bds_Impl_Debug", (DL_FUNC) &_Rblpapi_bds_Impl_Debug, 8},
     {"_Rblpapi_getPortfolio_Impl", (DL_FUNC) &_Rblpapi_getPortfolio_Impl, 7},
     {"_Rblpapi_beqs_Impl", (DL_FUNC) &_Rblpapi_beqs_Impl, 7},
     {"_Rblpapi_blpConnect_Impl", (DL_FUNC) &_Rblpapi_blpConnect_Impl, 3},

--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -39,7 +39,7 @@ using BloombergLP::blpapi::Element;
 using BloombergLP::blpapi::Message;
 using BloombergLP::blpapi::MessageIterator;
 
-void populateDfRowBDS(SEXP ans, R_len_t row_index, Element& e) {
+void populateDfRowBDS(Rcpp::RObject ans, R_len_t row_index, Element& e) {
     if (e.isNull()) { return; }
 
     switch(e.datatype()) {
@@ -104,8 +104,8 @@ void populateDfRowBDS(SEXP ans, R_len_t row_index, Element& e) {
 }
 
 // deprecated -- still needed by BDS
-SEXP allocateDataFrameColumn(int fieldT, size_t n) {
-    SEXP ans;
+Rcpp::RObject allocateDataFrameColumn(int fieldT, size_t n) {
+    Rcpp::RObject ans;
 
     switch(fieldT) {
     case BLPAPI_DATATYPE_BOOL:
@@ -192,8 +192,8 @@ LazyFrameIteratorT assertColumnDefined(LazyFrameT& lazy_frame, BloombergLP::blpa
 
     // insert only if not present
     if (iter == lazy_frame.end()) {
-        SEXP column = allocateDataFrameColumn(e.datatype(), n);
-        iter = lazy_frame.insert(lazy_frame.begin(),std::pair<std::string,SEXP>(e.name().string(),column));
+        Rcpp::RObject column = allocateDataFrameColumn(e.datatype(), n);
+        iter = lazy_frame.insert(lazy_frame.begin(),std::pair<std::string,Rcpp::RObject>(e.name().string(),column));
     }
 
   return iter;


### PR DESCRIPTION
Debugging and potential fix of BDS crashes from #253

Added a bds_debug function to send thousands of bds requests in rapid succession. This helps reliably and quickly reproduce the error. See also tinytests/test_segfault.R

My hunch is that unprotected SEXP in bds.cpp get destroyed by garbage collection. After changing SEXP to Rcpp::RObject throughout bds.cpp, I could no longer reproduce the error. However, I do not have sufficient theoretical knowledge of SEXP to know for sure.