### PR TITLE
Switch from knitr+rmarkdown+minidown to simplermarkdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Date: 2021-10-15
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils
-Suggests: fts, xts, zoo, data.table, knitr, rmarkdown, minidown, tinytest
-VignetteBuilder: knitr
+Suggests: fts, xts, zoo, data.table, simplermarkdown, tinytest
+VignetteBuilder: simplermarkdown
 LazyLoad: yes
 StagedInstall: no
 LinkingTo: Rcpp, BH

--- a/vignettes/rblpapi-intro.md
+++ b/vignettes/rblpapi-intro.md
@@ -1,16 +1,13 @@
+<!--
+%\VignetteIndexEntry{Introducing Rblpapi}
+%\VignetteEngine{simplermarkdown::mdweave_to_html}
+%\VignetteEncoding{UTF-8}
+-->
 ---
 title: "Introducing Rblpapi"
 author: "Dirk Eddelbuettel"
 date: "2015-08-13"
-output:
-  minidown::mini_document:
-    framework: water
-    toc: true
-    toc_float: true
-vignette: >
-  %\VignetteIndexEntry{Introducing Rblpapi}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+css: "water.css"
 ---
 
 ## Introduction

--- a/vignettes/water.css
+++ b/vignettes/water.css
@@ -1,0 +1,84 @@
+/* our addition */
+body {
+  max-width: 50rem;
+  margin-left: auto;
+  margin-right: auto;
+  font-family: system-ui;
+}
+
+/* Inline codes */
+code {
+  padding: 2px;
+  border-radius: unset;
+}
+
+/* Code blocks */
+
+pre {
+  background-color: unset;
+  border: solid #aaa 1px;
+  padding: 8px;
+}
+
+pre.numberSource {
+  margin: 0;
+  padding-left: 0;
+}
+
+div.sourceCode {
+  overflow: visible;
+}
+pre, pre.sourceCode {
+  overflow-x: auto;
+}
+pre>code {
+  white-space: pre;
+  overflow: visible;
+  background-color: unset;
+  padding: 0;
+}
+
+pre.sourceCode.numberSource {
+  overflow-x: visible;
+}
+pre.sourceCode.numberSource>code {
+  white-space: pre-wrap
+}
+pre.sourceCode.numberSource>code>span {
+  left: 8px;
+  text-indent: -4.6em;
+}
+
+/* code folding */
+.chunk-summary {
+  text-align: right;
+}
+.chunk-summary+pre,
+.chunk-summary+div.sourceCode {
+  margin-top: 2px;
+}
+
+/* TOC */
+nav > ul {
+  border: .0625rem solid #444;
+  border-radius: 4px;
+  margin: 5px;
+  padding: 5px;
+}
+nav ul {
+  list-style-type: none;
+  padding-inline-start: 1rem;
+}
+nav ul li {
+  padding: 0;
+}
+nav ul ul {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+nav code {
+  background-color: unset;
+  color: unset;
+}


### PR DESCRIPTION
This PR suggests to follow a practice I just introduced in six of my own packages to replace use of packages `knitr`, `rmarkdown` and (for the CSS formatting) `minidown` (which taken together have a bit of footprint) with the _much simpler_ new package `simplermarkdown` which only needs one other package (for JSON) (plus a tiny CSS file) and wraps `pandoc` directly.  See the reverse suggests of [simplermarkdown](https://cloud.r-project.org/package=simplermarkdown) for examples.

Our vignette only used `pandoc` for code formatting and actually ran no R code (which is not uncommon) so the switch was trivial.  I put a locally rendered html version of the vignette [here](https://dirk.eddelbuettel.com/tmp/rblpapi-intro.html) if you want to peruse it. 

As for motivation, I find this (done via package `deepdep`) quite illustrative:

![image](https://user-images.githubusercontent.com/673121/144865223-b5caeae2-97f9-4d56-849d-38e85a38c8e1.png)

All that said, this is of course not _required_ as a change but merely reflects my usage preference and experience.  We can easily leave things as they are for no harm.  So if the majority vote is "no change" we can close this PR.
