### PR TITLE
Add test_bds.R

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-12-22  Michael Kerber  <mtkerber@gmail.com>
+
+	* inst/tinytest/test_bds.R: Added file, test for return type of function 'bds'
+
 2021-12-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): New release 0.3.12

--- a/inst/tinytest/test_bds.R
+++ b/inst/tinytest/test_bds.R
@@ -1,0 +1,33 @@
+
+# Copyright (C) 2016 - 2021  Dirk Eddelbuettel, Whit Armstrong and John Laing
+#
+# This file is part of Rblpapi.
+#
+# Rblpapi is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Rblpapi is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+library(tinytest)
+
+.runThisTest <- Sys.getenv("RunRblpapiUnitTests") == "yes"
+if (!.runThisTest) exit_file("Skipping this file")
+
+library(Rblpapi)
+
+#test.bdsResult <- function() {
+res <- bds("DAX Index", "INDX_MEMBERS")
+expect_true(inherits(res, "list"), info = "checking return type")
+expect_true(inherits(res[[1]], "data.frame"), info = "checking return type of first element")
+expect_error(bds(c("DAX Index", "SPX Index"), "INDX_MEMBERS"), info = "more than one security")
+expect_error(bds(c("DAX Index", "SPX Index"), c("INDX_MEMBERS", "IVOL_SURFACE")), info = "more than one field")
+expect_error(bds("DAX Index", c("INDX_MEMBERS", "IVOL_SURFACE")), info = "more than one security and more than one field")
+#    }


### PR DESCRIPTION
As discussed in #351 :

Adds a file to test return type of function `bds`. 
Note that this checks for the behaviour as of 0.3.11, i.e. bds returning a list whose first element is a data.frame