### PR TITLE
Generalize configure for optional use of local library and header archives

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,11 @@
 2022-02-21  Dirk Eddelbuettel  <edd@debian.org>
 
+        * DESCRIPTION (Version, Date): Roll minor version
+
 	* configure: Generalize to let blpHeaders and blpLibrary environment
 	variable provide a local archive, download as usual if unset
+
+	* DESCRIPTION (SystemRequirements): Minor edit
 
 2022-01-09  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-02-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* configure: Generalize to let blpHeaders and blpLibrary environment
+	variable provide a local archive, download as usual if unset
+
 2022-01-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): New release 0.3.13

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.13
-Date: 2022-01-09
+Version: 0.3.13.1
+Date: 2022-02-21
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils
@@ -15,9 +15,7 @@ SystemRequirements: A valid Bloomberg installation. The API headers and
  dynamic library are downloaded from <https://github.com/Rblp/blp> during the
  build step. See <https://bloomberg.github.io/blpapi-docs/cpp/3.8> as well as
  <https://www.bloomberg.com/professional/support/api-library/> for API
- documentation. A compiler recent enough for (at least partial) C++11
- support is required; g++-4.6.* or later should be sufficient and g++-4.9.*
- or later is preferred.
+ documentation. A recent-enough compiler with C++11 support is required.
 URL: https://dirk.eddelbuettel.com/code/rblpapi.html, https://github.com/Rblp/Rblpapi
 BugReports: https://github.com/Rblp/Rblpapi/issues
 License: file LICENSE

--- a/configure
+++ b/configure
@@ -70,23 +70,32 @@ download() {
     fi
 }
 
-## Get and install header files
+## default file names, can override with say 'blpHeaders="/opt/blp/blpHeaders_1.2.3.tar.gz"'
+## respects enviroment variable so 'blpHeaders="/opt/blp/blpHeaders_1.2.3.tar.gz" ./configure' works
+: ${blpHeaders="blpHeaders.tar.gz"}
+: ${blpLibrary="blpLibrary.tar.gz"}
+
+## Check for header files and download if needed
 cwd=$(pwd)
 mkdir -p blp/${platform}
 cd blp/${platform}
-if [ ! -f blpHeaders.tar.gz ]; then
+if [ ! -f ${blpHeaders} ]; then
     download https://github.com/Rblp/blp/raw/master/headers/${platform}/blpHeaders.tar.gz
-    tar xfz blpHeaders.tar.gz -C ../../inst
+else
+    echo "** using ${blpHeaders}"
 fi
+tar xfz ${blpHeaders} -C ../../inst
 cd ${cwd}
 
 ## Get and install precompiled shared library
 mkdir -p inst/blp
 cd blp/${platform}
-if [ ! -f blpLibrary.tar.gz ]; then
+if [ ! -f ${blpLibrary} ]; then
     download https://github.com/Rblp/blp/raw/master/${platform}${flavour}/blpLibrary.tar.gz
-    tar xfz blpLibrary.tar.gz -C ../../inst/blp/ libblpapi3_${flavour}.so
+else
+    echo "** using ${blpLibrary}"
 fi
+tar xfz ${blpLibrary} -C ../../inst/blp/ libblpapi3_${flavour}.so
 cd ${cwd}
 
 exit 0


### PR DESCRIPTION
This supercedes the PR in #360 

It has been tested at RHub -- links will last a few days as usual:
- [Windows, R-devel](https://builder.r-hub.io/status/Rblpapi_0.3.13.1.tar.gz-6637bc5a002946fd90a3524fc6f89f3c)
- [Fedora, R-devel](https://builder.r-hub.io/status/Rblpapi_0.3.13.1.tar.gz-c6f29ce7e4fa42b2913432373dfdbe2c)
- [Ubuntu, R-release](https://builder.r-hub.io/status/Rblpapi_0.3.13.1.tar.gz-c3da2a808c234484a1bdbe0e68e80d88)

As usage example was already provided [in this comment](https://github.com/Rblp/Rblpapi/pull/360#issuecomment-1046915361)