### PR TITLE
No longer enforce staged install

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-10-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/Makevars.in: Set rpath to relative path for staged installation
+	* configure: No longer set rpath
+	* DESCRIPTION: No longer impose non-staged installation
+
 2022-08-27  Bob Harlow  <rharlow86@gmail.com>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,6 @@ Imports: Rcpp (>= 0.11.0), utils
 Suggests: fts, xts, zoo, data.table, simplermarkdown, tinytest
 VignetteBuilder: simplermarkdown
 LazyLoad: yes
-StagedInstall: no
 LinkingTo: Rcpp, BH
 Description: An R Interface to 'Bloomberg' is provided via the 'Blp API'.
 SystemRequirements: A valid Bloomberg installation. The API headers and

--- a/configure
+++ b/configure
@@ -3,7 +3,7 @@
 ##
 ##  configure -- Unix build preparation system
 ##
-##  Copyright (C) 2015 - 2021  Dirk Eddelbuettel and Jeroen Ooms.
+##  Copyright (C) 2015 - 2022  Dirk Eddelbuettel and Jeroen Ooms.
 ##
 ##  This file is part of Rblpapi
 ##
@@ -41,15 +41,14 @@ else
 fi
 
 ## Populate Makevars
-rpath=$(${R_HOME}/bin/Rscript -e 'cat(file.path(.libPaths()[1], "Rblpapi", "blp"))')
 arch=$(uname -m)
 if [ "${arch}" = "x86_64" ]; then
     echo "Setting up compilation for a ${platform} 64-bit system"
-    sed -e"s/@config@/blpapi3_64/" -e"s|@rpath@|"${rpath}"|" src/Makevars.in > src/Makevars
+    sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
     flavour="64"
 elif [ "${arch}" = "i686" ]; then
     echo "Setting up compilation for a ${platform} 32-bit system"
-    sed -e"s/@config@/blpapi3_32/" -e"s|@rpath@|"${rpath}"|" src/Makevars.in > src/Makevars
+    sed -e"s/@config@/blpapi3_32/" src/Makevars.in > src/Makevars
     flavour="32"
 else
     echo "Unknown architecture: ${arch}. Exiting."

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -2,7 +2,8 @@
 ##
 ##  Makefile -- Unix build system
 ##
-##  Copyright (C) 2015  Dirk Eddelbuettel and Jeroen Ooms
+##  Copyright (C) 2015-present  Dirk Eddelbuettel and Jeroen Ooms
+##  Copyright (C) 2022          Tomas Kalibera and Dirk Eddelbuettel
 ##
 ##  This file is part of Rblpapi
 ##
@@ -25,7 +26,7 @@ CXX_STD      = CXX11
 
 ## filled in by configure
 BBG_LIB     = @config@
-BBG_RPATH   = @rpath@
+BBG_RPATH   = '$$ORIGIN/../blp'
 
 ## set include and linker options
 ## Bbg API files are assummed to be in the standard search path
@@ -33,4 +34,4 @@ PKG_CPPFLAGS = -I../inst/include/ -I.
 PKG_LIBS     = -l$(BBG_LIB) -L../inst/blp -Wl,-rpath,$(BBG_RPATH)
 
 all: $(SHLIB)
-	@if command -v install_name_tool; then echo "fixing"; install_name_tool -change libblpapi3_64.so '@rpath@/libblpapi3_64.so' Rblpapi.so; fi
+	@if command -v install_name_tool; then echo "fixing"; install_name_tool -change libblpapi3_64.so '@loader_path/../blp/libblpapi3_64.so' Rblpapi.so; fi


### PR DESCRIPTION
CRAN came knocking because our package is one of the remaining ones (the other is, <cough, cough> mine too ...) requiring to set `StagedInstall: no` in `DESCRIPTION`.  This goes _way_ back to when @jeroen helped us get to the package CRAN-ready and has to do with the fact that we (at the time) opted for _absolute_ paths via `@rpath` instructions to the dynamic linker.

Well turns out relative ones work too, and @kalibera was of excellent assistance here so this now works.  I also sent it to RHub's macOS test instance (that use the CRAN setup, not the one using `brew`) and it passed too.  This needed changes to no longer `Suggests:` on the now-departed `fts` package, I will send those in subsequent PR.
