### PR TITLE
Remove (optional) use of fts package now in package heaven

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2022-10-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Suggests): No longer suggest 'fts'
+ 	* R/bdh.R (bdh): Remove support for 'fts'
+	* R/getBars.R (getBars): Idem
+	* R/getTicks.R (getTicks): Idem
+	* inst/tinytest/test_bdh.R: Idem
+	* man/bdh.Rd: Remove documentation entry for 'fts'
+	* man/getBars.Rd: Idem
+	* man/getTicks.Rd: Idem
+
 2022-08-27  Bob Harlow  <rharlow86@gmail.com>
 
 	* DESCRIPTION (Version, Date): Roll minor version
@@ -10,6 +21,8 @@
 	* src/authenticate.cpp: Handle new parameters at the C++ level
 
 	* man/blpAuthenticate.R: document new parameters
+
+	* DESCRIPTION: No longer Suggests: fts
 
 2022-02-21  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
 Version: 0.3.13.2
-Date: 2022-02-21
+Date: 2022-10-04
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
 Imports: Rcpp (>= 0.11.0), utils
-Suggests: fts, xts, zoo, data.table, simplermarkdown, tinytest
+Suggests: xts, zoo, data.table, simplermarkdown, tinytest
 VignetteBuilder: simplermarkdown
 LazyLoad: yes
 StagedInstall: no

--- a/R/bdh.R
+++ b/R/bdh.R
@@ -39,7 +39,7 @@
 ##' desired, defaults to \sQuote{FALSE}
 ##' @param returnAs A character variable describing the type of return
 ##' object; currently supported are \sQuote{data.frame} (also the default),
-##' \sQuote{data.table}, \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}
+##' \sQuote{data.table}, \sQuote{xts} and \sQuote{zoo}
 ##' @param identity An optional identity object as created by a
 ##' \code{blpAuthenticate} call, and retrieved via the internal function
 ##' \code{defaultAuthentication}.
@@ -94,7 +94,7 @@ bdh <- function(securities, fields, start.date, end.date=NULL,
                 identity=defaultAuthentication(), con=defaultConnection(),
                 int.as.double=getOption("blpIntAsDouble", FALSE),
                 simplify=getOption("blpSimplify", TRUE)) {
-    match.arg(returnAs, c("data.frame", "fts", "xts", "zoo", "data.table"))
+    match.arg(returnAs, c("data.frame", "xts", "zoo", "data.table"))
     if (class(start.date) == "Date") {
         start.date <- format(start.date, format="%Y%m%d")
     }
@@ -113,7 +113,6 @@ bdh <- function(securities, fields, start.date, end.date=NULL,
     
     res <- switch(returnAs,
                   data.frame = res,            # default is data.frame
-                  fts        = lapply(res, function(x) fts::fts(x[,1], x[,-1, drop = FALSE])),
                   xts        = lapply(res, function(x) xts::xts(x[,-1, drop = FALSE], order.by = x[,1])),
                   zoo        = lapply(res, function(x) zoo::zoo(x[,-1, drop = FALSE], order.by = x[,1])),
                   data.table = lapply(res, function(x) data.table::data.table(date = data.table::as.IDate(x[, 1]), x[, -1, drop = FALSE])),

--- a/R/blpAuthenticate.R
+++ b/R/blpAuthenticate.R
@@ -1,6 +1,6 @@
 
 ##
-##  Copyright (C) 2015  Whit Armstrong and Dirk Eddelbuettel and John Laing
+##  Copyright (C) 2015 - 2022  Whit Armstrong and Dirk Eddelbuettel and John Laing
 ##
 ##  This file is part of Rblpapi
 ##

--- a/R/getBars.R
+++ b/R/getBars.R
@@ -35,7 +35,7 @@
 ##' desired, defaults to \sQuote{FALSE}
 ##' @param returnAs A character variable describing the type of return
 ##' object; currently supported are \sQuote{matrix} (also the default),
-##' \sQuote{fts}, \sQuote{xts}, \sQuote{zoo} and \sQuote{data.table}
+##' \sQuote{xts}, \sQuote{zoo} and \sQuote{data.table}
 ##' @param tz A character variable with the desired local timezone,
 ##' defaulting to the value \sQuote{TZ} environment variable, and
 ##' \sQuote{UTC} if unset
@@ -68,7 +68,7 @@ getBars <- function(security,
                     tz = Sys.getenv("TZ", unset="UTC"),
                     con = defaultConnection()) {
 
-    match.arg(returnAs, c("matrix", "fts", "xts", "zoo", "data.table"))
+    match.arg(returnAs, c("matrix", "xts", "zoo", "data.table"))
     if (!inherits(startTime, "POSIXt") || !inherits(endTime, "POSIXt")) {
         stop("startTime and endTime must be Datetime objects", call.=FALSE)
     }
@@ -82,7 +82,6 @@ getBars <- function(security,
 
     res <- switch(returnAs,
                   matrix     = res,                # default is matrix
-                  fts        = fts::fts(res[,1], res[,-1]),
                   xts        = xts::xts(res[,-1], order.by=res[,1]),
                   zoo        = zoo::zoo(res[,-1], order.by=res[,1]),
                   data.table = asDataTable(res),

--- a/R/getBars.R
+++ b/R/getBars.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2015 - 2017  Whit Armstrong and Dirk Eddelbuettel and John Laing
+##  Copyright (C) 2015 - 2022  Whit Armstrong and Dirk Eddelbuettel and John Laing
 ##
 ##  This file is part of Rblpapi
 ##

--- a/R/getTicks.R
+++ b/R/getTicks.R
@@ -1,6 +1,6 @@
 
 ##
-##  Copyright (C) 2015 - 2016  Whit Armstrong and Dirk Eddelbuettel and John Laing
+##  Copyright (C) 2015 - 2022  Whit Armstrong and Dirk Eddelbuettel and John Laing
 ##
 ##  This file is part of Rblpapi
 ##

--- a/R/getTicks.R
+++ b/R/getTicks.R
@@ -41,7 +41,7 @@
 ##' desired, defaults to \sQuote{FALSE}
 ##' @param returnAs A character variable describing the type of return
 ##' object; currently supported are \sQuote{data.frame} (also the default),
-##' \sQuote{data.table}, \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}
+##' \sQuote{data.table}, \sQuote{xts} and \sQuote{zoo}
 ##' @param tz A character variable with the desired local timezone,
 ##' defaulting to the value \sQuote{TZ} environment variable, and
 ##' \sQuote{UTC} if unset
@@ -51,7 +51,7 @@
 ##' @return Depending on the value of \sQuote{returnAs}, either a
 ##' \sQuote{data.frame} or \sQuote{data.table} object also containing
 ##' non-numerical information such as condition codes, or a time-indexed
-##' container of type \sQuote{fts}, \sQuote{xts} and \sQuote{zoo} with
+##' container of type \sQuote{xts} or \sQuote{zoo} with
 ##' a numeric matrix containing only \sQuote{value} and \sQuote{size}.
 ##' @author Dirk Eddelbuettel
 ##' @examples
@@ -72,7 +72,7 @@ getTicks <- function(security,
                      tz = Sys.getenv("TZ", unset="UTC"),
                      con = defaultConnection()) {
 
-    match.arg(returnAs, c("data.frame", "fts", "xts", "zoo", "data.table"))
+    match.arg(returnAs, c("data.frame", "xts", "zoo", "data.table"))
     if (!inherits(startTime, "POSIXt") || !inherits(endTime, "POSIXt")) {
         stop("startTime and endTime must be Datetime objects", call.=FALSE)
     }
@@ -89,7 +89,6 @@ getTicks <- function(security,
     ## return data, but omit event type which is character type
     res <- switch(returnAs,
                   data.frame = res,            # default is data.frame
-                  fts        = fts::fts(res[,1], res[,-c(1:2,5)]),
                   xts        = xts::xts(res[,-c(1:2,5)], order.by=res[,1]),
                   zoo        = zoo::zoo(res[,-c(1:2,5)], order.by=res[,1]),
                   data.table = asDataTable(res),

--- a/inst/tinytest/test_bdh.R
+++ b/inst/tinytest/test_bdh.R
@@ -35,7 +35,7 @@ expect_true(dim(res)[1] >= 5, info = "check return of five rows - data.table")
 expect_true(dim(res)[2] == 4, info = "check return of four cols - data.table")
 expect_true(all(c("PX_LAST","OPEN_INT","FUT_CUR_GEN_TICKER") %in% colnames(res)), info = "check column names - data.table")
 
-for (retAs in c("fts", "xts", "zoo")) {
+for (retAs in c("xts", "zoo")) {
     res <- bdh("TY1 Comdty",c("PX_OPEN", "PX_HIGH", "PX_LOW", "PX_LAST"),Sys.Date()-10,returnAs=retAs)
     expect_true(inherits(res, retAs), info = paste("checking return type -", retAs))
     expect_true(dim(res)[1] >= 5, info = paste("check return of five rows -", retAs))

--- a/man/bdh.Rd
+++ b/man/bdh.Rd
@@ -38,7 +38,7 @@ desired, defaults to \sQuote{FALSE}}
 
 \item{returnAs}{A character variable describing the type of return
 object; currently supported are \sQuote{data.frame} (also the default),
-\sQuote{data.table}, \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}}
+\sQuote{data.table}, \sQuote{xts} and \sQuote{zoo}}
 
 \item{identity}{An optional identity object as created by a
 \code{blpAuthenticate} call, and retrieved via the internal function

--- a/man/getBars.Rd
+++ b/man/getBars.Rd
@@ -33,7 +33,7 @@ desired, defaults to \sQuote{FALSE}}
 
 \item{returnAs}{A character variable describing the type of return
 object; currently supported are \sQuote{matrix} (also the default),
-\sQuote{fts}, \sQuote{xts}, \sQuote{zoo} and \sQuote{data.table}}
+\sQuote{xts}, \sQuote{zoo} and \sQuote{data.table}}
 
 \item{tz}{A character variable with the desired local timezone,
 defaulting to the value \sQuote{TZ} environment variable, and

--- a/man/getTicks.Rd
+++ b/man/getTicks.Rd
@@ -26,7 +26,7 @@ desired, defaults to \sQuote{FALSE}}
 
 \item{returnAs}{A character variable describing the type of return
 object; currently supported are \sQuote{data.frame} (also the default),
-\sQuote{data.table}, \sQuote{fts}, \sQuote{xts} and \sQuote{zoo}}
+\sQuote{data.table}, \sQuote{xts} and \sQuote{zoo}}
 
 \item{tz}{A character variable with the desired local timezone,
 defaulting to the value \sQuote{TZ} environment variable, and
@@ -40,7 +40,7 @@ call, and retrieved via the internal function
 Depending on the value of \sQuote{returnAs}, either a
 \sQuote{data.frame} or \sQuote{data.table} object also containing
 non-numerical information such as condition codes, or a time-indexed
-container of type \sQuote{fts}, \sQuote{xts} and \sQuote{zoo} with
+container of type \sQuote{xts} and \sQuote{zoo} with
 a numeric matrix containing only \sQuote{value} and \sQuote{size}.
 }
 \description{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // authenticate_Impl
 SEXP authenticate_Impl(SEXP con_, SEXP uuid_, SEXP ip_address_, SEXP is_auth_id_, SEXP app_name_);
 RcppExport SEXP _Rblpapi_authenticate_Impl(SEXP con_SEXP, SEXP uuid_SEXP, SEXP ip_address_SEXP, SEXP is_auth_id_SEXP, SEXP app_name_SEXP) {


### PR DESCRIPTION
This PR removes reference to the (always optional) package `fts` which is no longer on CRAN.

It is probably best to first merge #373 and to then rebase, but the two reviews can happen concurrently.