### PR TITLE
Update GitHub Actions to actions/checkout@v4 and r-ci-setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout 
+        uses: actions/checkout@v4
 
-      - name: Get Script
-        run: curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci-setup@master
 
       - name: Bootstrap
         run: ./run.sh bootstrap

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-02-23  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .github/workflows/ci.yaml (jobs): Update to actions/checkout@v4,
+	add r-ci-setup actions
+
 2022-12-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml (jobs): Update to actions/checkout@v3


### PR DESCRIPTION
Some minor maintenance I have been doing to a number of my other repos.  I find the 'versioned' schema of the actions quite silly as we are forced to increment it every few years.  Oh well.  Still a free service that works well.