### PR TITLE
Avoid deprecation warnings over char* instead of Name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# 4 space indentation
+[*.{c,cpp,h,hpp,R,r}]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -3,7 +3,7 @@
 ##  Makefile -- Unix build system
 ##
 ##  Copyright (C) 2015-present  Dirk Eddelbuettel and Jeroen Ooms
-##  Copyright (C) 2022          Tomas Kalibera and Dirk Eddelbuettel
+##  Copyright (C) 2022-present  Tomas Kalibera and Dirk Eddelbuettel
 ##
 ##  This file is part of Rblpapi
 ##
@@ -19,10 +19,6 @@
 ##
 ##  You should have received a copy of the GNU General Public License
 ##  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
-
-
-## use C++11
-CXX_STD      = CXX11
 
 ## filled in by configure
 BBG_LIB     = @config@

--- a/src/bdh.cpp
+++ b/src/bdh.cpp
@@ -2,7 +2,7 @@
 //  bdh.cpp -- "Bloomberg Data History" query function for the BLP API
 //
 //  Copyright (C) 2013      Whit Armstrong
-//  Copyright (C) 2015-204  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2015-2024 Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //

--- a/src/bdh.cpp
+++ b/src/bdh.cpp
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  bdh.cpp -- "Bloomberg Data History" query function for the BLP API
 //
-//  Copyright (C) 2013  Whit Armstrong
-//  Copyright (C) 2015  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2013      Whit Armstrong
+//  Copyright (C) 2015-204  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -39,6 +38,7 @@ using BloombergLP::blpapi::Event;
 using BloombergLP::blpapi::Element;
 using BloombergLP::blpapi::Message;
 using BloombergLP::blpapi::MessageIterator;
+using BloombergLP::blpapi::Name;
 
 std::string getSecurityName(Event& event) {
     MessageIterator msgIter(event);
@@ -52,8 +52,8 @@ std::string getSecurityName(Event& event) {
         throw std::logic_error("Not a valid HistoricalDataResponse.");
     }
 
-    Element securityData = response.getElement("securityData");
-    std::string ans(securityData.getElementAsString("security"));
+    Element securityData = response.getElement(Name{"securityData"});
+    std::string ans(securityData.getElementAsString(Name{"security"}));
     return ans;
 }
 
@@ -70,8 +70,8 @@ Rcpp::List HistoricalDataResponseToDF(Event& event, const std::vector<std::strin
     if (std::strcmp(response.name().string(),"HistoricalDataResponse")) {
         throw std::logic_error("Not a valid HistoricalDataResponse.");
     }
-    Element securityData = response.getElement("securityData");
-    Element fieldData = securityData.getElement("fieldData");
+    Element securityData = response.getElement(Name{"securityData"});
+    Element fieldData = securityData.getElement(Name{"fieldData"});
 
     Rcpp::List res(allocateDataFrame(fieldData.numValues(), fields, rtypes));
 
@@ -99,7 +99,7 @@ Rcpp::List bdh_Impl(SEXP con_,
                     bool verbose, SEXP identity_,
                     bool int_as_double) {
 
-    Session* session = 
+    Session* session =
         reinterpret_cast<Session*>(checkExternalPointer(con_,"blpapi::Session*"));
 
 
@@ -125,9 +125,9 @@ Rcpp::List bdh_Impl(SEXP con_,
     Request request = refDataService.createRequest("HistoricalDataRequest");
     createStandardRequest(request, securities, fields, options_, overrides_);
 
-    request.set("startDate", start_date_.c_str());
+    request.set(Name{"startDate"}, start_date_.c_str());
     if (end_date_ != R_NilValue) {
-        request.set("endDate", Rcpp::as<std::string>(end_date_).c_str());
+        request.set(Name{"endDate"}, Rcpp::as<std::string>(end_date_).c_str());
     }
 
     sendRequestWithIdentity(session, request, identity_);

--- a/src/bdp.cpp
+++ b/src/bdp.cpp
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  bdp.cpp -- "Bloomberg Data Point" query function for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2015 - 2016  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -43,6 +42,7 @@ using BloombergLP::blpapi::Event;
 using BloombergLP::blpapi::Element;
 using BloombergLP::blpapi::Message;
 using BloombergLP::blpapi::MessageIterator;
+using BloombergLP::blpapi::Name;
 
 void getBDPResult(Event& event, Rcpp::List& res, const std::vector<std::string>& securities, const std::vector<std::string>& colnames, const std::vector<RblpapiT>& rtypes, bool verbose) {
     MessageIterator msgIter(event);
@@ -55,17 +55,17 @@ void getBDPResult(Event& event, Rcpp::List& res, const std::vector<std::string>&
     if (std::strcmp(response.name().string(),"ReferenceDataResponse")) {
         throw std::logic_error("Not a valid ReferenceDataResponse.");
     }
-    Element securityData = response.getElement("securityData");
+    Element securityData = response.getElement(Name{"securityData"});
 
     for (size_t i = 0; i < securityData.numValues(); ++i) {
         Element this_security = securityData.getValueAsElement(i);
-        size_t row_index = this_security.getElement("sequenceNumber").getValueAsInt32();
+        size_t row_index = this_security.getElement(Name{"sequenceNumber"}).getValueAsInt32();
 
         // check that the seqNum matches the order of the securities vector (it's a grave error to screw this up)
-        if(securities[row_index].compare(this_security.getElementAsString("security"))!=0) {
+        if(securities[row_index].compare(this_security.getElementAsString(Name{"security"}))!=0) {
             throw std::logic_error("mismatched Security sequence, please report a bug.");
         }
-        Element fieldData = this_security.getElement("fieldData");
+        Element fieldData = this_security.getElement(Name{"fieldData"});
         for(size_t j = 0; j < fieldData.numElements(); ++j) {
             Element e = fieldData.getElement(j);
             auto col_iter = std::find(colnames.begin(), colnames.end(), e.name().string());

--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  bds.cpp -- "Bloomberg Data Set" query function for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2015 - 2017  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -38,6 +37,7 @@ using BloombergLP::blpapi::Event;
 using BloombergLP::blpapi::Element;
 using BloombergLP::blpapi::Message;
 using BloombergLP::blpapi::MessageIterator;
+using BloombergLP::blpapi::Name;
 
 void populateDfRowBDS(Rcpp::RObject ans, R_len_t row_index, Element& e) {
     if (e.isNull()) { return; }
@@ -60,7 +60,7 @@ void populateDfRowBDS(Rcpp::RObject ans, R_len_t row_index, Element& e) {
             Rcpp::Rcerr << "BLPAPI_DATATYPE_INT64 exceeds max int value on this system (assigning std::numeric_limits<int>::max())." << std::endl;
             INTEGER(ans)[row_index] = std::numeric_limits<int>::max();
         } else {
-            INTEGER(ans)[row_index] = static_cast<int>(e.getValueAsInt64()); 
+            INTEGER(ans)[row_index] = static_cast<int>(e.getValueAsInt64());
         }
         break;
     case BLPAPI_DATATYPE_FLOAT32:
@@ -227,19 +227,19 @@ Rcpp::List BulkDataResponseToDF(Event& event, std::string& requested_field, std:
     if(std::strcmp(response.name().string(),response_type.c_str())) {
         throw std::logic_error("Not a valid " + response_type + ".");
     }
-    Element securityData = response.getElement("securityData");
+    Element securityData = response.getElement(Name{"securityData"});
 
     Rcpp::List ans(securityData.numValues());
     std::vector<std::string> ans_names(securityData.numValues());
 
     for(size_t i = 0; i < securityData.numValues(); ++i) {
         Element this_security = securityData.getValueAsElement(i);
-        ans_names[i] = this_security.getElementAsString("security");
-        Element fieldData = this_security.getElement("fieldData");
-        if(!fieldData.hasElement(requested_field.c_str())) {
+        ans_names[i] = this_security.getElementAsString(Name{"security"});
+        Element fieldData = this_security.getElement(Name{"fieldData"});
+        if(!fieldData.hasElement(Name{requested_field.c_str()})) {
             ans[i] = R_NilValue;
         } else {
-            Element e = fieldData.getElement(requested_field.c_str());
+            Element e = fieldData.getElement(Name{requested_field.c_str()});
             ans[i] = bulkArrayToDf(e);
         }
     }
@@ -266,9 +266,9 @@ Rcpp::List bds_Impl(SEXP con_, std::vector<std::string> securities,
     Service refDataService = session->getService(rdsrv.c_str());
     Request request = refDataService.createRequest("ReferenceDataRequest");
     for (size_t i = 0; i < securities.size(); i++) {
-        request.getElement("securities").appendValue(securities[i].c_str());
+        request.getElement(Name{"securities"}).appendValue(Name{securities[i].c_str()});
     }
-    request.getElement("fields").appendValue(field.c_str());
+    request.getElement(Name{"fields"}).appendValue(Name{field.c_str()});
     appendOptionsToRequest(request,options_);
     appendOverridesToRequest(request,overrides_);
 
@@ -311,9 +311,9 @@ Rcpp::List getPortfolio_Impl(SEXP con_, std::vector<std::string> securities,
     Service refDataService = session->getService(rdsrv.c_str());
     Request request = refDataService.createRequest("PortfolioDataRequest");
     for (size_t i = 0; i < securities.size(); i++) {
-        request.getElement("securities").appendValue(securities[i].c_str());
+        request.getElement(Name{"securities"}).appendValue(Name{securities[i].c_str()});
     }
-    request.getElement("fields").appendValue(field.c_str());
+    request.getElement(Name{"fields"}).appendValue(Name{field.c_str()});
     appendOptionsToRequest(request,options_);
     appendOverridesToRequest(request,overrides_);
 

--- a/src/bsrch.cpp
+++ b/src/bsrch.cpp
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  bsrch.cpp -- "Bloomberg SRCH" query function for the BLP API
 //
-//  Copyright (C) 2015  Whit Armstrong and Dirk Eddelbuettel and John Laing
+//  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel and John Laing
 //
 //  This file is part of Rblpapi
 //
@@ -50,6 +49,7 @@ using BloombergLP::blpapi::Event;
 using BloombergLP::blpapi::Element;
 using BloombergLP::blpapi::Message;
 using BloombergLP::blpapi::MessageIterator;
+using BloombergLP::blpapi::Name;
 
 Rcpp::DataFrame processBsrchResponse(Event event, const bool verbose) {
 
@@ -65,12 +65,12 @@ Rcpp::DataFrame processBsrchResponse(Event event, const bool verbose) {
 
     // exrsvc provides a grid in the form of DataRecords
     // Extract the dimensions and key attributes before processing
-    Element dataRecords = msg.getElement("DataRecords");
+    Element dataRecords = msg.getElement(Name{"DataRecords"});
 
-    int numRows = msg.getElementAsInt64("NumOfRecords");
+    int numRows = msg.getElementAsInt64(Name{"NumOfRecords"});
     if (verbose) Rcpp::Rcout << numRows << " records returned" << std::endl;
 
-    Element columnTitles = msg.getElement("ColumnTitles");
+    Element columnTitles = msg.getElement(Name{"ColumnTitles"});
     int numCols = columnTitles.numValues();
     if (verbose) Rcpp::Rcout << "Returned columns:" << std::endl;
     if (verbose) columnTitles.print(Rcpp::Rcout);
@@ -94,10 +94,10 @@ Rcpp::DataFrame processBsrchResponse(Event event, const bool verbose) {
             // DataFieldArray
                 // DataField --> value
     // TODO - this step could made simpler for exrsvc queries as they always
-    // return values as a Choice 
+    // return values as a Choice
     for (int i = 0; i < min(numRows, 25); i++) { 		                 // look at up to 25 rows to infer types
         Element dataRecord = dataRecords.getValueAsElement(i); 	         // pick i-th element to infer DataRecord type
-        Element dataFields = dataRecord.getElement("DataFields");        // get data payload of first element
+        Element dataFields = dataRecord.getElement(Name{"DataFields"});  // get data payload of first element
 
         for (int j=0; j< numCols; j++) { 			                     // loop over first data set, and infer types
             if (!chk(j)) {                                               // column has not been set yet
@@ -139,7 +139,7 @@ Rcpp::DataFrame processBsrchResponse(Event event, const bool verbose) {
     for (int i = 0; i < numRows; i++) {
 
         Element dataRecord = dataRecords.getValueAsElement(i);
-        Element dataFields = dataRecord.getElement("DataFields");
+        Element dataFields = dataRecord.getElement(Name{"DataFields"});
         if (verbose) dataFields.print(Rcpp::Rcout);
 
         for (int j = 0; j < numCols; j++) {
@@ -189,7 +189,7 @@ DataFrame bsrch_Impl(SEXP con,
     Service exrService = session->getService(exrsrv.c_str());
     Request request = exrService.createRequest("ExcelGetGridRequest");
 
-    request.getElement("Domain").setValue(domain.c_str());
+    request.getElement(Name{"Domain"}).setValue(Name{domain.c_str()});
 
     // TODO - implement limit and other overrides
 

--- a/src/fieldsearch.cpp
+++ b/src/fieldsearch.cpp
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  fieldsearch.cpp -- a simple field search function for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2014 - 2015  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2024  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -73,8 +72,8 @@ Rcpp::DataFrame fieldSearch_Impl(SEXP con, std::string searchterm) {
 
     bbg::Service fieldInfoService = session->getService(APIFLDS_SVC);
     bbg::Request request = fieldInfoService.createRequest("FieldSearchRequest");
-    request.set ("searchSpec", searchterm.c_str());
-    request.set ("returnFieldDocumentation", false);
+    request.set(bbg::Name{"searchSpec"}, searchterm.c_str());
+    request.set(bbg::Name{"returnFieldDocumentation"}, false);
     session->sendRequest(request);
 
     std::vector<std::string> fieldId, fieldMnen, fieldDesc;
@@ -89,7 +88,7 @@ Rcpp::DataFrame fieldSearch_Impl(SEXP con, std::string searchterm) {
         bbg::MessageIterator msgIter(event);
         while (msgIter.next()) {
             bbg::Message msg = msgIter.message();
-            bbg::Element fields = msg.getElement("fieldData");
+            bbg::Element fields = msg.getElement(bbg::Name{"fieldData"});
             int numElements = fields.numValues();
             //Rprintf("Seeing %d elements\n", numElements);
             for (int i=0; i < numElements; i++) {

--- a/src/getBars.cpp
+++ b/src/getBars.cpp
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  getBars.cpp -- a simple intraday bar retriever
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2014 - 2015  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2024  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -176,12 +175,12 @@ Rcpp::DataFrame getBars_Impl(SEXP con,
     bbg::Request request = refDataService.createRequest("IntradayBarRequest");
 
     // only one security/eventType per request
-    request.set("security", security.c_str());
-    request.set("eventType", eventType.c_str());
-    request.set("interval", barInterval);
+    request.set(bbg::Name{"security"}, security.c_str());
+    request.set(bbg::Name{"eventType"}, eventType.c_str());
+    request.set(bbg::Name{"interval"}, barInterval);
 
-    request.set("startDateTime", startDateTime.c_str());
-    request.set("endDateTime", endDateTime.c_str());
+    request.set(bbg::Name{"startDateTime"}, startDateTime.c_str());
+    request.set(bbg::Name{"endDateTime"}, endDateTime.c_str());
     if (options.isNotNull()) {
         appendOptionsToRequest(request, options);
     }
@@ -225,6 +224,3 @@ Rcpp::DataFrame getBars_Impl(SEXP con,
                                    Rcpp::Named("value")     = bars.value);
 
 }
-
-
-

--- a/src/getTicks.cpp
+++ b/src/getTicks.cpp
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  getTicks.cpp -- a simple intraday tick retriever
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2014 - 2016  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2024  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -68,7 +67,7 @@
 #include <Rcpp.h>
 #include <blpapi_utils.h>
 
-namespace bbg = BloombergLP::blpapi;	// shortcut to not globally import both namespace
+namespace bbg = BloombergLP::blpapi;	// shortcut to not globally import both namespaces
 
 namespace {
     const bbg::Name TICK_DATA("tickData");
@@ -118,7 +117,7 @@ void processMessage(bbg::Message &msg, Ticks &ticks, const bool verbose) {
                         << std::endl;
         }
         ticks.time.push_back(bbgDatetimeToUTC(time));
-        ticks.type.push_back(type);    
+        ticks.type.push_back(type);
         ticks.value.push_back(value);
         ticks.size.push_back(size);
         ticks.conditionCode.push_back(conditionCode);
@@ -143,7 +142,7 @@ Rcpp::DataFrame getTicks_Impl(SEXP con,
                               std::vector<std::string> eventType,
                               std::string startDateTime,
                               std::string endDateTime,
-                              bool setCondCodes=true,  
+                              bool setCondCodes=true,
                               bool verbose=false) {
 
     // via Rcpp Attributes we get a try/catch block with error propagation to R "for free"
@@ -158,17 +157,17 @@ Rcpp::DataFrame getTicks_Impl(SEXP con,
     bbg::Request request = refDataService.createRequest("IntradayTickRequest");
 
     // only one security/eventType per request
-    request.set("security", security.c_str());
+    request.set(bbg::Name{"security"}, security.c_str());
 
-    bbg::Element eventTypes = request.getElement("eventTypes");
+    bbg::Element eventTypes = request.getElement(bbg::Name{"eventTypes"});
     for (size_t i = 0; i < eventType.size(); i++) {
         eventTypes.appendValue(eventType[i].c_str());
     }
-    
-    request.set("includeConditionCodes", setCondCodes);
-    request.set("includeNonPlottableEvents", setCondCodes);
-    request.set("startDateTime", startDateTime.c_str());
-    request.set("endDateTime", endDateTime.c_str());
+
+    request.set(bbg::Name{"includeConditionCodes"}, setCondCodes);
+    request.set(bbg::Name{"includeNonPlottableEvents"}, setCondCodes);
+    request.set(bbg::Name{"startDateTime"}, startDateTime.c_str());
+    request.set(bbg::Name{"endDateTime"}, endDateTime.c_str());
 
     if (verbose) Rcpp::Rcout <<"Sending Request: " << request << std::endl;
     session->sendRequest(request);
@@ -200,10 +199,9 @@ Rcpp::DataFrame getTicks_Impl(SEXP con,
     }
 
     return Rcpp::DataFrame::create(Rcpp::Named("times") = createPOSIXtVector(ticks.time),
-                                   Rcpp::Named("type") = ticks.type, 
+                                   Rcpp::Named("type") = ticks.type,
                                    Rcpp::Named("value") = ticks.value,
-                                   Rcpp::Named("size")  = ticks.size, 
+                                   Rcpp::Named("size")  = ticks.size,
     	                           Rcpp::Named("condcode") = ticks.conditionCode);
 
 }
-

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 //  lookup.cpp -- symbol look-up
 //
-//  Copyright (C) 2017  Dirk Eddelbuettel and Kevin Jin
+//  Copyright (C) 2017 - 2024  Dirk Eddelbuettel and Kevin Jin
 //
 //  This file is part of Rblpapi
 //
@@ -55,7 +54,7 @@ void processMessage(bbg::Message &msg, InstrumentListResults &matches, const boo
         throw std::logic_error("Not a valid InstrumentListResponse.");
     }
 
-    bbg::Element data = response.getElement("results");
+    bbg::Element data = response.getElement(bbg::Name{"results"});
     int numItems = data.numValues();
     if (verbose) {
         Rcpp::Rcout <<"Response contains " << numItems << " items" << std::endl;
@@ -70,7 +69,7 @@ void processMessage(bbg::Message &msg, InstrumentListResults &matches, const boo
             Rcpp::Rcout << security << "\t\t" << description << std::endl;
         }
         matches.security.push_back(security);
-        matches.description.push_back(description);    
+        matches.description.push_back(description);
     }
 }
 
@@ -105,10 +104,10 @@ Rcpp::DataFrame lookup_Impl(SEXP con,
     bbg::Service secfService = session->getService("//blp/instruments");
     bbg::Request request = secfService.createRequest("instrumentListRequest");
 
-    request.set("query", query.c_str());
-    request.set("yellowKeyFilter", yellowKeyFilter.c_str());
-    request.set("languageOverride", languageOverride.c_str());
-    request.set("maxResults", maxResults);
+    request.set(bbg::Name{"query"}, query.c_str());
+    request.set(bbg::Name{"yellowKeyFilter"}, yellowKeyFilter.c_str());
+    request.set(bbg::Name{"languageOverride"}, languageOverride.c_str());
+    request.set(bbg::Name{"maxResults"}, maxResults);
 
     if (verbose) Rcpp::Rcout <<"Sending Request: " << request << std::endl;
     session->sendRequest(request);


### PR DESCRIPTION
Also removes now-outdated hard-wiring of C++11 as a compilation standard and adds an .editorconfig file.

The library update (via an update to the blp repo) will follow.