### PR TITLE
Package maintenance: DESCRIPTION, README, .Rbuildignore updates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,11 +1,13 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^local
-.travis.yml
+^\.travis.yml
 ^deprecated
 ^blp
 ^inst/blp
 src/Makevars$
-.Rhistory
+^\.Rhistory
 ^.*\.tar\.gz$
 ^\.github
+^\.editorconfig
+fullCleanup.sh

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+2024-08-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+
+	* DESCRIPTION (Authors@R): Added
+
+	* README.md: Switch CI badge to GitHub Actions
+
+2024-08-25  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/authenticate.cpp: Use Name{} instantiation instead of char*
+	* src/bdh.cpp: Idem
+	* src/bdp.cpp: Idem
+	* src/bds.cpp: Idem
+	* src/beqs.cpp: Idem
+	* src/blpapi_utils.cpp: Idem
+	* src/fieldsearch.cpp: Idem
+	* src/getBars.cpp: Idem
+	* src/getTicks.cpp: Idem
+	* src/lookup.cpp: Idem
+
+	* src/Makevars.in: Remove obsolete C++11 setter
+
+	* .editorconfig: Added
+
 2024-07-15  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Switch some URLs from http to https

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,11 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.14
-Date: 2022-10-05
-Maintainer: Dirk Eddelbuettel <edd@debian.org>
-Author: Whit Armstrong, Dirk Eddelbuettel and John Laing
+Version: 0.3.14.1
+Date: 2024-08-27
+Authors@R: c(person("Whit", "Armstrong", role = "aut"),
+             person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
+                  comment = c(ORCID = "0000-0001-6419-907X")),
+             person("John", "Laing", role = "aut"))
 Imports: Rcpp (>= 0.11.0), utils
 Suggests: xts, zoo, data.table, simplermarkdown, tinytest
 VignetteBuilder: simplermarkdown

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 ## Rblpapi: R Access to Bloomberg API
 
-[![Build Status](https://travis-ci.org/Rblp/Rblpapi.svg)](https://travis-ci.org/Rblp/Rblpapi) 
-[![Package-License](http://img.shields.io/badge/license-GPL--3-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-3.0.html) 
-[![LibraryLicense](https://img.shields.io/badge/license-License.txt-yellow.svg?style=flat)](https://raw.githubusercontent.com/Rblp/Rblpapi/master/inst/License.txt) 
-[![CRAN](https://www.r-pkg.org/badges/version/Rblpapi)](https://cran.r-project.org/package=Rblpapi) 
-[![Dependencies](https://tinyverse.netlify.app/badge/Rblpapi)](https://cran.r-project.org/package=Rblpapi) 
+[![Build Status](https://github.com/Rblp/Rblpapi/actions/workflows/ci.yaml/badge.svg)](https://github.com/Rblp/Rblpapi/actions/workflows/ci.yaml)
+[![Package-License](http://img.shields.io/badge/license-GPL--3-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-3.0.html)
+[![LibraryLicense](https://img.shields.io/badge/license-License.txt-yellow.svg?style=flat)](https://raw.githubusercontent.com/Rblp/Rblpapi/master/inst/License.txt)
+[![CRAN](https://www.r-pkg.org/badges/version/Rblpapi)](https://cran.r-project.org/package=Rblpapi)
+[![Dependencies](https://tinyverse.netlify.app/badge/Rblpapi)](https://cran.r-project.org/package=Rblpapi)
 [![Downloads](https://cranlogs.r-pkg.org/badges/Rblpapi?color=brightgreen)](https://www.r-pkg.org:443/pkg/Rblpapi)
 [![Last Commit](https://img.shields.io/github/last-commit/Rblp/Rblpapi)](https://github.com/Rblp/Rblpapi)
 
@@ -14,7 +14,7 @@
 Rblpapi provides R with access to data and calculations from Bloomberg
 Finance L.P. via the [API libraries](https://www.bloomberg.com/professional/support/api-library/) provided by
 Bloomberg.
- 
+
 
 ### Requirements
 
@@ -28,25 +28,25 @@ Here are a few simple examples.
 library(Rblpapi)
 con <- blpConnect() 	# automatic if option("blpAutoConnect") is TRUE
 
-spx <- bdh(securities = "SPX Index", 
-           fields = "PX_LAST", 
+spx <- bdh(securities = "SPX Index",
+           fields = "PX_LAST",
            start.date = as.Date("2013-03-01"))
 
-spx_ndx <- bdh(securities = c("SPX Index","NDX Index"), 
+spx_ndx <- bdh(securities = c("SPX Index","NDX Index"),
                fields = "PX_LAST",
-               start.date = as.Date("2013-03-01"), 
+               start.date = as.Date("2013-03-01"),
                include.non.trading.days = TRUE)
 
 monthly.options <- structure(c("ACTUAL", "MONTHLY"),
                             names = c("periodicityAdjustment",
                                       "periodicitySelection"))
-spx_ndx_monthly <- bdh(securities = c("SPX Index","NDX Index"), 
+spx_ndx_monthly <- bdh(securities = c("SPX Index","NDX Index"),
                        fields = "PX_LAST",
-                       start.date = as.Date("2012-01-01"), 
+                       start.date = as.Date("2012-01-01"),
                        options = monthly.options)
 
 goog_ge_div <- bdh(securities = c("GOOG US Equity","GE US Equity"),
-                   fields = c("PX_LAST","CF_DVD_PAID"), 
+                   fields = c("PX_LAST","CF_DVD_PAID"),
                    start.date = as.Date("2012-11-01"))
 
 goog_ge_px <- bdp(securities = c("GOOG US Equity","GE US Equity"),
@@ -84,5 +84,3 @@ Whit Armstrong, Dirk Eddelbuettel and John Laing
 GPL-3 for our code
 
 [License.txt](inst/License.txt) for the Bloomberg libraries and headers it relies upon
-
-


### PR DESCRIPTION
This PR regroups a few cleanups such as
- increment the version to indicate change from last release
- switch to Authors@R which CRAN now requires, if you have [ORCID IDs](https://orcid.org/) we can add them
- switch the CI badge to the CI we actually use
- minor .Rbuildignore update

Nothing critical but all _en route_ to updating the API libraries which is pending.