### PR TITLE
Correct request formation as identified in #393

### DIFF
--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -266,7 +266,7 @@ Rcpp::List bds_Impl(SEXP con_, std::vector<std::string> securities,
     Service refDataService = session->getService(rdsrv.c_str());
     Request request = refDataService.createRequest("ReferenceDataRequest");
     for (size_t i = 0; i < securities.size(); i++) {
-        request.getElement(Name{"securities"}).appendValue(Name{securities[i].c_str()});
+        request.getElement(Name{"securities"}).appendValue(securities[i].c_str());
     }
     request.getElement(Name{"fields"}).appendValue(Name{field.c_str()});
     appendOptionsToRequest(request,options_);

--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -268,7 +268,7 @@ Rcpp::List bds_Impl(SEXP con_, std::vector<std::string> securities,
     for (size_t i = 0; i < securities.size(); i++) {
         request.getElement(Name{"securities"}).appendValue(securities[i].c_str());
     }
-    request.getElement(Name{"fields"}).appendValue(Name{field.c_str()});
+    request.getElement(Name{"fields"}).appendValue(field.c_str());
     appendOptionsToRequest(request,options_);
     appendOverridesToRequest(request,overrides_);
 
@@ -311,9 +311,9 @@ Rcpp::List getPortfolio_Impl(SEXP con_, std::vector<std::string> securities,
     Service refDataService = session->getService(rdsrv.c_str());
     Request request = refDataService.createRequest("PortfolioDataRequest");
     for (size_t i = 0; i < securities.size(); i++) {
-        request.getElement(Name{"securities"}).appendValue(Name{securities[i].c_str()});
+        request.getElement(Name{"securities"}).appendValue(securities[i].c_str());
     }
-    request.getElement(Name{"fields"}).appendValue(Name{field.c_str()});
+    request.getElement(Name{"fields"}).appendValue(field.c_str());
     appendOptionsToRequest(request,options_);
     appendOverridesToRequest(request,overrides_);
 


### PR DESCRIPTION
As identified by @mtkerbeR in #393, there was a `Name{}` invocation too many which bricked `bds()`.  This restores it.

Many thanks to @mtkerbeR for catching this and the patient testing.