### PR TITLE
Use release 3.24.6.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         include:
-          #- {os: macOS-latest}
+          - {os: macOS-latest}
           - {os: ubuntu-latest}
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup
@@ -34,6 +34,10 @@ jobs:
 
       - name: Test
         run: ./run.sh run_tests
+
+      - name: Logs
+        run: ./run.sh dump_logs
+        if: failure()
 
       #- name: Coverage
       #  if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,8 @@
 	* src/lookup.cpp: Idem
 
 	* src/Makevars.in: Remove obsolete C++11 setter
+	* src/Makevars.in: Set to development branch of blp repo for testing
+	* src/Makevars.win: Idem
 
 	* .editorconfig: Added
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2024-09-05  John Laing  <john.laing@gmail.com>
+
+	* src/bsrch.cpp: Correct over-use of Name{}
+	* R/bsrch.R: Add example of bsrch()
+	* man/bsrch.R: Idem
+
+2024-09-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/bds.cpp: Correct over-use of Name{}
+
 2024-08-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,9 +14,9 @@ LinkingTo: Rcpp, BH
 Description: An R Interface to 'Bloomberg' is provided via the 'Blp API'.
 SystemRequirements: A valid Bloomberg installation. The API headers and
  dynamic library are downloaded from <https://github.com/Rblp/blp> during the
- build step. See <https://bloomberg.github.io/blpapi-docs/cpp/3.8> as well as
+ build step. See <https://bloomberg.github.io/blpapi-docs/cpp/3.24.6> as well as
  <https://www.bloomberg.com/professional/support/api-library/> for API
- documentation. A recent-enough compiler with C++11 support is required.
+ documentation.
 URL: https://dirk.eddelbuettel.com/code/rblpapi.html, https://github.com/Rblp/Rblpapi
 BugReports: https://github.com/Rblp/Rblpapi/issues
 License: file LICENSE

--- a/configure
+++ b/configure
@@ -77,14 +77,15 @@ download() {
 ## respects enviroment variable so 'blpHeaders="/opt/blp/blpHeaders_1.2.3.tar.gz" ./configure' works
 : ${blpHeaders="blpHeaders.tar.gz"}
 : ${blpLibrary="blpLibrary.tar.gz"}
+#: ${blpBranch="master"}
+: ${blpBranch="feature/release_3.24.6.1"}
 
 ## Check for header files and download if needed
 cwd=$(pwd)
 mkdir -p blp/${platform}
 cd blp/${platform}
 if [ ! -f ${blpHeaders} ]; then
-    #download https://github.com/Rblp/blp/raw/master/headers/${platform}/blpHeaders.tar.gz
-    download https://github.com/Rblp/blp/raw/feature/release_3.24.6.1/headers/${platform}/blpHeaders.tar.gz
+    download https://github.com/Rblp/blp/raw/${blpBranch}/headers/${platform}/blpHeaders.tar.gz
 else
     echo "** using ${blpHeaders}"
 fi
@@ -95,8 +96,7 @@ cd ${cwd}
 mkdir -p inst/blp
 cd blp/${platform}
 if [ ! -f ${blpLibrary} ]; then
-    #download https://github.com/Rblp/blp/raw/master/${platform}${flavour}/blpLibrary.tar.gz
-    download https://github.com/Rblp/blp/raw/feature/release_3.24.6.1/${platform}${flavour}/blpLibrary.tar.gz
+    download https://github.com/Rblp/blp/raw/${blpBranch}/${platform}${flavour}/blpLibrary.tar.gz
 else
     echo "** using ${blpLibrary}"
 fi

--- a/configure
+++ b/configure
@@ -3,7 +3,7 @@
 ##
 ##  configure -- Unix build preparation system
 ##
-##  Copyright (C) 2015 - 2022  Dirk Eddelbuettel and Jeroen Ooms.
+##  Copyright (C) 2015 - 2024  Dirk Eddelbuettel and Jeroen Ooms.
 ##
 ##  This file is part of Rblpapi
 ##
@@ -46,6 +46,10 @@ if [ "${arch}" = "x86_64" ]; then
     echo "Setting up compilation for a ${platform} 64-bit system"
     sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
     flavour="64"
+elif [ "${arch}" = "arm64" ]; then
+    echo "Setting up compilation for a ${platform} 64-bit system"
+    sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
+    flavour="64"
 elif [ "${arch}" = "i686" ]; then
     echo "Setting up compilation for a ${platform} 32-bit system"
     sed -e"s/@config@/blpapi3_32/" src/Makevars.in > src/Makevars
@@ -79,7 +83,8 @@ cwd=$(pwd)
 mkdir -p blp/${platform}
 cd blp/${platform}
 if [ ! -f ${blpHeaders} ]; then
-    download https://github.com/Rblp/blp/raw/master/headers/${platform}/blpHeaders.tar.gz
+    #download https://github.com/Rblp/blp/raw/master/headers/${platform}/blpHeaders.tar.gz
+    download https://github.com/Rblp/blp/raw/feature/release_3.24.6.1/headers/${platform}/blpHeaders.tar.gz
 else
     echo "** using ${blpHeaders}"
 fi
@@ -90,7 +95,8 @@ cd ${cwd}
 mkdir -p inst/blp
 cd blp/${platform}
 if [ ! -f ${blpLibrary} ]; then
-    download https://github.com/Rblp/blp/raw/master/${platform}${flavour}/blpLibrary.tar.gz
+    #download https://github.com/Rblp/blp/raw/master/${platform}${flavour}/blpLibrary.tar.gz
+    download https://github.com/Rblp/blp/raw/feature/release_3.24.6.1/${platform}${flavour}/blpLibrary.tar.gz
 else
     echo "** using ${blpLibrary}"
 fi

--- a/configure
+++ b/configure
@@ -46,10 +46,16 @@ if [ "${arch}" = "x86_64" ]; then
     echo "Setting up compilation for a ${platform} 64-bit system"
     sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
     flavour="64"
+    if [ "${platform}" = "osx" ]; then
+        cpu="x86"
+    fi
 elif [ "${arch}" = "arm64" ]; then
     echo "Setting up compilation for a ${platform} 64-bit system"
     sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
     flavour="64"
+    if [ "${platform}" = "osx" ]; then
+        cpu="arm"
+    fi
 elif [ "${arch}" = "i686" ]; then
     echo "Setting up compilation for a ${platform} 32-bit system"
     sed -e"s/@config@/blpapi3_32/" src/Makevars.in > src/Makevars
@@ -80,7 +86,7 @@ download() {
 #: ${blpBranch="master"}
 : ${blpBranch="feature/release_3.24.6.1"}
 
-## Check for header files and download if needed
+## Check for header files and download if needed, this looks at repo blp in directory headers/
 cwd=$(pwd)
 mkdir -p blp/${platform}
 cd blp/${platform}
@@ -92,11 +98,13 @@ fi
 tar xfz ${blpHeaders} -C ../../inst
 cd ${cwd}
 
-## Get and install precompiled shared library
+## Get and install precompiled shared library, this looks at repo blp in directoris 'PlatformFlavourCpu'
+## Here flavour is mostly redundant as of 2024 as 32 bit is no longer built at CRAN but we support user who may have it
+## The Cpu tag is used only on macos and it used to distinguish between (old) x86_64 and newer arm64
 mkdir -p inst/blp
 cd blp/${platform}
 if [ ! -f ${blpLibrary} ]; then
-    download https://github.com/Rblp/blp/raw/${blpBranch}/${platform}${flavour}/blpLibrary.tar.gz
+    download https://github.com/Rblp/blp/raw/${blpBranch}/${platform}${flavour}${cpu}/blpLibrary.tar.gz
 else
     echo "** using ${blpLibrary}"
 fi

--- a/configure
+++ b/configure
@@ -83,8 +83,7 @@ download() {
 ## respects enviroment variable so 'blpHeaders="/opt/blp/blpHeaders_1.2.3.tar.gz" ./configure' works
 : ${blpHeaders="blpHeaders.tar.gz"}
 : ${blpLibrary="blpLibrary.tar.gz"}
-#: ${blpBranch="master"}
-: ${blpBranch="feature/release_3.24.6.1"}
+: ${blpBranch="master"}
 
 ## Check for header files and download if needed, this looks at repo blp in directory headers/
 cwd=$(pwd)

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -30,4 +30,4 @@ PKG_CPPFLAGS = -I../inst/include/ -I.
 PKG_LIBS     = -l$(BBG_LIB) -L../inst/blp -Wl,-rpath,$(BBG_RPATH)
 
 all: $(SHLIB)
-	@if command -v install_name_tool; then echo "fixing"; install_name_tool -change libblpapi3_64.so '@loader_path/../blp/libblpapi3_64.so' Rblpapi.so; fi
+	@if command -v install_name_tool; then echo "fixing"; install_name_tool -add_rpath @loader_path/../blp Rblpapi.so; fi

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,7 +2,7 @@
 ##
 ##  Makefile.win -- Windows build system
 ##
-##  Copyright (C) 2015  Whit Armstrong and Dirk Eddelbuettel
+##  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel
 ##
 ##  This file is part of Rblpapi
 ##
@@ -28,7 +28,7 @@ else
 endif
 
 ## Standard compiler / linker flags including windows flavor
-CXX_STD = CXX11
+# CXX_STD = CXX11
 PKG_CPPFLAGS = -I../inst/include -I.
 PKG_LIBS = -lblpapi3_${WIN} -L${FLV}
 
@@ -40,11 +40,13 @@ all:    	blpLibrary $(SHLIB)
 ## the opening '@' ensures operations are executed 'quietly'
 ## in order to see commands as they happens add a 'v' to the tar and cp commands
 ## curl has '-k' flag to suppress certificate warnings
+#BRANCH = "master"
+BRANCH = "feature/release_3.24.6.1"
 blpLibrary:
 		@if [ ! -d ../inst ]; then mkdir -p ../inst; fi
 		@if [ ! -d ../blp/win/${FLV} ]; then mkdir -p ../blp/win/${FLV}; fi
-		@if [ ! -f ../blp/win/${FLV}/blpHeaders.tar.gz ]; then curl -s -k -L -O https://github.com/Rblp/blp/raw/master/headers/windows/blpHeaders.tar.gz; mv blpHeaders.tar.gz ../blp/win/${FLV}; tar xfz ../blp/win/${FLV}/blpHeaders.tar.gz -C ../inst; fi
-		@if [ ! -f ../blp/win/${FLV}/blpLibrary.tar.gz ]; then curl -s -k -L -O https://github.com/Rblp/blp/raw/master/win${WIN}/blpLibrary.tar.gz; mv blpLibrary.tar.gz ../blp/win/${FLV}; tar xfz ../blp/win/${FLV}/blpLibrary.tar.gz; fi
+		@if [ ! -f ../blp/win/${FLV}/blpHeaders.tar.gz ]; then curl -s -k -L -O https://github.com/Rblp/blp/raw/${BRANCH}/headers/windows/blpHeaders.tar.gz; mv blpHeaders.tar.gz ../blp/win/${FLV}; tar xfz ../blp/win/${FLV}/blpHeaders.tar.gz -C ../inst; fi
+		@if [ ! -f ../blp/win/${FLV}/blpLibrary.tar.gz ]; then curl -s -k -L -O https://github.com/Rblp/blp/raw/${BRANCH}/win${WIN}/blpLibrary.tar.gz; mv blpLibrary.tar.gz ../blp/win/${FLV}; tar xfz ../blp/win/${FLV}/blpLibrary.tar.gz; fi
 		@if [ ! -d ${FLV} ]; then mkdir -p ${FLV}; fi
 		@cp blpapi3_${WIN}.dll ${FLV}
 		@if [ ! -d ../inst/libs/${FLV} ]; then mkdir -p ../inst/libs/${FLV}; fi

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -40,8 +40,7 @@ all:    	blpLibrary $(SHLIB)
 ## the opening '@' ensures operations are executed 'quietly'
 ## in order to see commands as they happens add a 'v' to the tar and cp commands
 ## curl has '-k' flag to suppress certificate warnings
-#BRANCH = "master"
-BRANCH = "feature/release_3.24.6.1"
+BRANCH = "master"
 blpLibrary:
 		@if [ ! -d ../inst ]; then mkdir -p ../inst; fi
 		@if [ ! -d ../blp/win/${FLV} ]; then mkdir -p ../blp/win/${FLV}; fi


### PR DESCRIPTION
This PR switches to release 3.24.6.1 of the Bloomberg API, and enables arm64 builds for macOS.

We attempted to resurrect x86_64 builds for macOS.  As the current release of the Bloomberg API supports only arm64 on macOS, we retain the previouse.  And while that built fine previously it somehow now fails (at r-universe) for that platform.  It may hence also fail at CRAN for macOS x86_64.  We would need to rely on someone with that platform to debug more locally.

After approving please **do not merge immediately** but allow me to do so also in preparation of a next release.