### PR TITLE
Quota error handling on bdp request

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-11-25  Rodolphe Duge  <rodolphe.duge-de-bernonville@metori.com>
+
+	* src/bdp.c: Quota error handling on bdp request
+
 2024-09-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): New release 0.3.15

--- a/src/bdp.cpp
+++ b/src/bdp.cpp
@@ -55,6 +55,19 @@ void getBDPResult(Event& event, Rcpp::List& res, const std::vector<std::string>&
     if (std::strcmp(response.name().string(),"ReferenceDataResponse")) {
         throw std::logic_error("Not a valid ReferenceDataResponse.");
     }
+
+    const Name responseError("responseError");
+    if (response.hasElement(responseError)) {
+        Element errorElement = msg.getElement(responseError);
+        std::string errMsg("");
+        const Name messageTag("message");
+        if (errorElement.hasElement(messageTag)) {
+            errMsg = errorElement.getElementAsString(messageTag);
+        }
+        Rcpp::Rcerr << "REQUEST FAILED: " <<  errorElement << std::endl;
+        throw std::logic_error("bdp result: a responseError was received with message: (" + errMsg + ")");
+    }
+
     Element securityData = response.getElement(Name{"securityData"});
 
     for (size_t i = 0; i < securityData.numValues(); ++i) {


### PR DESCRIPTION
When doing a bdp request, we can receive an error message (quota ...)
in the result which gives the following error message:

_Choice sub-element not found for name 'securityData'._

Log the received message and throw an exception to have a clearer error message.
