### PR TITLE
add appIdentityKey optional argument to blpConnect()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -25,8 +25,8 @@ beqs_Impl <- function(con, screenName, screenType, group, pitdate, languageId, v
     .Call(`_Rblpapi_beqs_Impl`, con, screenName, screenType, group, pitdate, languageId, verbose)
 }
 
-blpConnect_Impl <- function(host, port, app_name_) {
-    .Call(`_Rblpapi_blpConnect_Impl`, host, port, app_name_)
+blpConnect_Impl <- function(host, port, app_name_, app_identity_key_) {
+    .Call(`_Rblpapi_blpConnect_Impl`, host, port, app_name_, app_identity_key_)
 }
 
 #' This function retrieves the version of Bloomberg API headers.

--- a/R/blpConnect.R
+++ b/R/blpConnect.R
@@ -33,6 +33,8 @@
 ##' to connect to bpipe. If this is NULL Rblpapi connects to the
 ##' Bloomberg API but cannot authenticate with an app name. This requires
 ##' the user to authenticate with a user uuid.
+##' @param appIdentityKey the application identity key. For Desktop API,
+##' this is generated from the APRE screen on Bloomberg terminal.
 ##' @return In the \code{default=TRUE} case nothing is returned, and
 ##' this connection is automatically used for all future calls which
 ##' omit the \code{con} argument. Otherwise a connection object is
@@ -58,10 +60,11 @@
 blpConnect <- function(host=getOption("blpHost", "localhost"),
                        port=getOption("blpPort", 8194L),
                        default=TRUE,
-                       appName = getOption("blpAppName", NULL)) {
+                       appName = getOption("blpAppName", NULL),
+                       appIdentityKey = getOption("blpAppIdentityKey", NULL)) {
     if (storage.mode(port) != "integer") port <- as.integer(port)
     if (storage.mode(host) != "character") stop("Host argument must be character.", call.=FALSE)
-    con <- blpConnect_Impl(host, port, appName)
+    con <- blpConnect_Impl(host, port, appName, appIdentityKey)
 
     if (default) .pkgenv$con <- con else return(con)
 }

--- a/man/blpConnect.Rd
+++ b/man/blpConnect.Rd
@@ -6,7 +6,8 @@
 \usage{
 blpConnect(host = getOption("blpHost", "localhost"),
   port = getOption("blpPort", 8194L), default = TRUE,
-  appName = getOption("blpAppName", NULL))
+  appName = getOption("blpAppName", NULL),
+  appIdentityKey = getOption("blpAppIdentityKey", NULL))
 }
 \arguments{
 \item{host}{A character option with either a machine name that is
@@ -24,6 +25,9 @@ user. Default to \code{TRUE}.}
 to connect to bpipe. If this is NULL Rblpapi connects to the
 Bloomberg API but cannot authenticate with an app name. This requires
 the user to authenticate with a user uuid.}
+
+\item{appIdentityKey}{the application identity key. For Desktop API,
+this is generated from the APRE screen on Bloomberg terminal.}
 }
 \value{
 In the \code{default=TRUE} case nothing is returned, and

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -115,15 +115,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // blpConnect_Impl
-SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_);
-RcppExport SEXP _Rblpapi_blpConnect_Impl(SEXP hostSEXP, SEXP portSEXP, SEXP app_name_SEXP) {
+SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_, SEXP app_identity_key_);
+RcppExport SEXP _Rblpapi_blpConnect_Impl(SEXP hostSEXP, SEXP portSEXP, SEXP app_name_SEXP, SEXP app_identity_key_SEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string >::type host(hostSEXP);
     Rcpp::traits::input_parameter< const int >::type port(portSEXP);
     Rcpp::traits::input_parameter< SEXP >::type app_name_(app_name_SEXP);
-    rcpp_result_gen = Rcpp::wrap(blpConnect_Impl(host, port, app_name_));
+    Rcpp::traits::input_parameter< SEXP >::type app_identity_key_(app_identity_key_SEXP);
+    rcpp_result_gen = Rcpp::wrap(blpConnect_Impl(host, port, app_name_, app_identity_key_));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -260,7 +261,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_Rblpapi_bds_Impl", (DL_FUNC) &_Rblpapi_bds_Impl, 7},
     {"_Rblpapi_getPortfolio_Impl", (DL_FUNC) &_Rblpapi_getPortfolio_Impl, 7},
     {"_Rblpapi_beqs_Impl", (DL_FUNC) &_Rblpapi_beqs_Impl, 7},
-    {"_Rblpapi_blpConnect_Impl", (DL_FUNC) &_Rblpapi_blpConnect_Impl, 3},
+    {"_Rblpapi_blpConnect_Impl", (DL_FUNC) &_Rblpapi_blpConnect_Impl, 4},
     {"_Rblpapi_getHeaderVersion", (DL_FUNC) &_Rblpapi_getHeaderVersion, 0},
     {"_Rblpapi_getRuntimeVersion", (DL_FUNC) &_Rblpapi_getRuntimeVersion, 0},
     {"_Rblpapi_bsrch_Impl", (DL_FUNC) &_Rblpapi_bsrch_Impl, 4},

--- a/src/blpConnect.cpp
+++ b/src/blpConnect.cpp
@@ -44,7 +44,7 @@ static void sessionFinalizer(SEXP session_) {
 }
 
 // [[Rcpp::export]]
-SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_) {
+SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_, SEXP app_identity_key_) {
     SessionOptions sessionOptions;
     sessionOptions.setServerHost(host.c_str());
     sessionOptions.setServerPort(port);
@@ -53,6 +53,10 @@ SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_) {
         std::string app_name = Rcpp::as<std::string>(app_name_);
         std::string authentication_string = APP_PREFIX + app_name;
         sessionOptions.setAuthenticationOptions(authentication_string.c_str());
+    }
+    if (app_identity_key_ != R_NilValue) {
+        std::string app_identity_key = Rcpp::as<std::string>(app_identity_key_);
+        sessionOptions.setApplicationIdentityKey(app_identity_key);
     }
     Session* sp = new Session(sessionOptions);
 

--- a/src/blpConnect.cpp
+++ b/src/blpConnect.cpp
@@ -73,7 +73,7 @@ SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_, SEX
 #else // ie if defined(NoBlpHere)
 
 #include <Rcpp/Lightest>
-SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_) {
+SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_, SEXP app_identity_key_) {
     return R_NilValue;
 }
 


### PR DESCRIPTION
See https://developer.bloomberg.com/portal/products/desktop_api?chapterId=4551&entityType=document#getting_started_with_desktop_api-app_registration

Seems similar to appName for B-PIPE, so just took inspiration from that. 