### PR TITLE
Make build more robust to absence of viable blp library and headers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2025-03-09  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version and date
+
 	* configure: Rework to actively support amd64 on Linux and arm64 on
 	macOS only and define -DNoBlpHere otherwise
 	* src/Makevars.in: Adjusted accordingly for link and install_name_tool

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+2025-03-09  Dirk Eddelbuettel  <edd@debian.org>
+
+	* configure: Rework to actively support amd64 on Linux and arm64 on
+	macOS only and define -DNoBlpHere otherwise
+	* src/Makevars.in: Adjusted accordingly for link and install_name_tool
+	* src/authenticate.cpp: Compilation reflects #if defined(NoBlpHere)
+        * src/bdh.cpp: Idem
+        * src/bdp.cpp: Idem
+        * src/bds.cpp: Idem
+        * src/beqs.cpp: Idem
+        * src/blpConnect.cpp: Idem
+        * src/blpVersion.cpp: Idem
+        * src/blpapi_utils.cpp: Idem
+        * src/bsrch.cpp: Idem
+        * src/fieldsearch.cpp: Idem
+        * src/getBars.cpp: Idem
+        * src/getFieldInfo.cpp: Idem
+        * src/getTicks.cpp: Idem
+        * src/lookup.cpp: Idem
+        * src/subscribe.cpp: Idem
+	* R/init.R: Startup message adjusted for build with/without blp
+
 2025-03-08  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml: Use r-ci action with embedded bootstrap

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rblpapi
 Title: R Interface to 'Bloomberg'
-Version: 0.3.15.1
-Date: 2024-12-04
+Version: 0.3.15.2
+Date: 2025-03-09
 Authors@R: c(person("Whit", "Armstrong", role = "aut"),
              person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),

--- a/R/init.R
+++ b/R/init.R
@@ -1,6 +1,6 @@
 
 ##
-##  Copyright (C) 2015 - 2016  Whit Armstrong and Dirk Eddelbuettel and John Laing
+##  Copyright (C) 2015 - 2025  Whit Armstrong and Dirk Eddelbuettel and John Laing
 ##
 ##  This file is part of Rblpapi
 ##
@@ -21,28 +21,33 @@
 .pkgenv <- new.env(parent=emptyenv())
 
 .onAttach <- function(libname, pkgname) {
-    packageStartupMessage(paste0("Rblpapi version ", packageVersion("Rblpapi"),
-                                 " using Blpapi headers ", getHeaderVersion(),
-                                 " and run-time ", getRuntimeVersion(), "."))
-    packageStartupMessage(paste0("Please respect the Bloomberg licensing agreement ",
-                                 "and terms of service."))
+    hrd <- getHeaderVersion()
+    rtm <- getRuntimeVersion()
+    if (nchar(hrd) + nchar(rtm) == 0) {
+        packageStartupMessage("No Blp available so no Rblapi functionality.")
+    } else {
+        packageStartupMessage(paste0("Rblpapi version ", packageVersion("Rblpapi"),
+                                     " using Blpapi headers ", hrd, " and run-time ", rtm, "."))
+        packageStartupMessage(paste0("Please respect the Bloomberg licensing agreement ",
+                                     "and terms of service."))
 
-    if (getOption("blpAutoConnect", FALSE)) {
-        con <- blpConnect()
-        if (getOption("blpVerbose", FALSE)) {
-            packageStartupMessage("Created and stored default connection object.")
+        if (getOption("blpAutoConnect", FALSE)) {
+            con <- blpConnect()
+            if (getOption("blpVerbose", FALSE)) {
+                packageStartupMessage("Created and stored default connection object.")
+            }
+        } else {
+            con <- NULL
         }
-    } else {
-        con <- NULL
-    }
-    if (getOption("blpAutoAuthenticate", FALSE)) {
-        blpAuth <- blpAuthenticate()
-        if (getOption("blpVerbose", FALSE)) {
-            packageStartupMessage("Created and stored default authentication object.")
+        if (getOption("blpAutoAuthenticate", FALSE)) {
+            blpAuth <- blpAuthenticate()
+            if (getOption("blpVerbose", FALSE)) {
+                packageStartupMessage("Created and stored default authentication object.")
+            }
+        } else {
+            blpAuth <- NULL
         }
-    } else {
-        blpAuth <- NULL
+        assign("con", con, envir=.pkgenv)
+        assign("blpAuth", blpAuth, envir=.pkgenv)
     }
-    assign("con", con, envir=.pkgenv)
-    assign("blpAuth", blpAuth, envir=.pkgenv)
 }

--- a/configure
+++ b/configure
@@ -3,7 +3,7 @@
 ##
 ##  configure -- Unix build preparation system
 ##
-##  Copyright (C) 2015 - 2024  Dirk Eddelbuettel and Jeroen Ooms.
+##  Copyright (C) 2015 - 2025  Dirk Eddelbuettel and Jeroen Ooms.
 ##
 ##  This file is part of Rblpapi
 ##
@@ -26,7 +26,8 @@ if ! [ -x $(command -v uname) ]; then
     exit 1
 fi
 
-## Check for Linux or OSX
+## Check for Linux or OSX. "These days" we support x86_64 on Linux and arm64 on macOS.
+## At CRAN or R-universe we encounter nothing else.
 : ${R_HOME=$(R RHOME)}
 sysname=$(${R_HOME}/bin/Rscript -e 'cat(Sys.info()["sysname"])')
 if [ ${sysname} = "Linux" ]; then
@@ -37,32 +38,38 @@ else
     echo "Unsupported platform: $sysname"
     echo "Check https://www.bloomberg.com/professional/support/api-library/ for possible support first."
     echo "Contributions welcome, see https://github.com/Rblp/blp for integration with Rblapi."
-    exit 2
+    echo "The build will proceed but not be functional for lack of a library."
+    sed -e"s/@config@//" -e"s/@badsystem@/-DNoBlpHere/" src/Makevars.in > src/Makevars
+    exit 0
 fi
 
 ## Populate Makevars
 arch=$(uname -m)
-if [ "${arch}" = "x86_64" ]; then
-    echo "Setting up compilation for a ${platform} 64-bit system"
-    sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
+if [ "${arch}" = "x86_64" -a "${platform}" = "linux" ]; then
+    echo "Setting up compilation for a ${platform} ${arch} system"
+    sed -e"s/@config@/-lblpapi3_64/" -e"s/@badsystem@//" src/Makevars.in > src/Makevars
     flavour="64"
-    if [ "${platform}" = "osx" ]; then
-        cpu="x86"
-    fi
-elif [ "${arch}" = "arm64" ]; then
-    echo "Setting up compilation for a ${platform} 64-bit system"
-    sed -e"s/@config@/blpapi3_64/" src/Makevars.in > src/Makevars
+    # this used to matter when Blp supported x86 on macos, they no longer do
+    #if [ "${platform}" = "osx" ]; then
+    #    cpu="x86"
+    #fi
+elif [ "${arch}" = "arm64" -a "${platform}" = "osx" ]; then
+    echo "Setting up compilation for a ${platform} ${arch} system"
+    sed -e"s/@config@/-lblpapi3_64/" -e"s/@badsystem@//" src/Makevars.in > src/Makevars
     flavour="64"
-    if [ "${platform}" = "osx" ]; then
-        cpu="arm"
-    fi
-elif [ "${arch}" = "i686" ]; then
-    echo "Setting up compilation for a ${platform} 32-bit system"
-    sed -e"s/@config@/blpapi3_32/" src/Makevars.in > src/Makevars
-    flavour="32"
+    #if [ "${platform}" = "osx" ]; then
+    #    cpu="arm"
+    #fi
+#elif [ "${arch}" = "i686" ]; then
+#    echo "Setting up compilation for a ${platform} 32-bit system"
+#    sed -e"s/@config@/blpapi3_32/" src/Makevars.in > src/Makevars
+#    flavour="32"
 else
-    echo "Unknown architecture: ${arch}. Exiting."
-    exit 3
+    echo "Unsupported platform and architecture combination: ${platform} ${arch}."
+    echo "The build will proceed but not be functional for lack of a library."
+    echo "If you need such a combination please get in touch with the Blp vendor."
+    sed -e"s/@config@//" -e"s/@badsystem@/-DNoBlpHere/" src/Makevars.in > src/Makevars
+    exit 0
 fi
 
 ## helper function to not rely on curl which at least on OS X fails to follow redirects

--- a/configure
+++ b/configure
@@ -57,9 +57,7 @@ elif [ "${arch}" = "arm64" -a "${platform}" = "osx" ]; then
     echo "Setting up compilation for a ${platform} ${arch} system"
     sed -e"s/@config@/-lblpapi3_64/" -e"s/@badsystem@//" src/Makevars.in > src/Makevars
     flavour="64"
-    #if [ "${platform}" = "osx" ]; then
-    #    cpu="arm"
-    #fi
+    cpu="arm"
 #elif [ "${arch}" = "i686" ]; then
 #    echo "Setting up compilation for a ${platform} 32-bit system"
 #    sed -e"s/@config@/blpapi3_32/" src/Makevars.in > src/Makevars

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -26,8 +26,8 @@ BBG_RPATH   = '$$ORIGIN/../blp'
 
 ## set include and linker options
 ## Bbg API files are assummed to be in the standard search path
-PKG_CPPFLAGS = -I../inst/include/ -I.
-PKG_LIBS     = -l$(BBG_LIB) -L../inst/blp -Wl,-rpath,$(BBG_RPATH)
+PKG_CPPFLAGS = -I../inst/include/ -I. @badsystem@
+PKG_LIBS     = $(BBG_LIB) -L../inst/blp -Wl,-rpath,$(BBG_RPATH)
 
 all: $(SHLIB)
-	@if command -v install_name_tool; then echo "fixing"; install_name_tool -add_rpath @loader_path/../blp Rblpapi.so; fi
+	@if command -v install_name_tool@badsystem@; then echo "fixing"; install_name_tool -add_rpath @loader_path/../blp Rblpapi.so; fi

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -30,4 +30,10 @@ PKG_CPPFLAGS = -I../inst/include/ -I. @badsystem@
 PKG_LIBS     = $(BBG_LIB) -L../inst/blp -Wl,-rpath,$(BBG_RPATH)
 
 all: $(SHLIB)
+        # we relt yn configure to replace @badsystem@ here to create a side effect
+        # notice that that there are only two outcomes we need to differentiate:
+        # - either (on a 'good' system with blp) we will in an empty string, so command -v works as
+        #   usual and we can run install_name_tool to add/update the rpath of shared librart
+        # - or on a bad system without blp we append -DNoBlpHere making command -v fail and avoiding
+        #   an install_name_call that would fails as we have no Rblpapi.so to adjust
 	@if command -v install_name_tool@badsystem@; then echo "fixing"; install_name_tool -add_rpath @loader_path/../blp Rblpapi.so; fi

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -30,7 +30,7 @@ PKG_CPPFLAGS = -I../inst/include/ -I. @badsystem@
 PKG_LIBS     = $(BBG_LIB) -L../inst/blp -Wl,-rpath,$(BBG_RPATH)
 
 all: $(SHLIB)
-        # we relt yn configure to replace @badsystem@ here to create a side effect
+        # we rely on configure to replace @badsystem@ here to create a side effect
         # notice that that there are only two outcomes we need to differentiate:
         # - either (on a 'good' system with blp) we will in an empty string, so command -v works as
         #   usual and we can run install_name_tool to add/update the rpath of shared librart

--- a/src/authenticate.cpp
+++ b/src/authenticate.cpp
@@ -2,8 +2,8 @@
 //  authenticate.cpp -- Function to authenticate to Bloomberg backend
 //
 //  Copyright (C) 2013      Whit Armstrong
-//  Copyright (C) 2015-2024 Whit Armstrong and Dirk Eddelbuettelp
-//  Copyright (C) 2019-2024 Whit Armstrong, Dirk Eddelbuettel and Alfred Kanzler
+//  Copyright (C) 2015-2025 Whit Armstrong and Dirk Eddelbuettelp
+//  Copyright (C) 2019-2025 Whit Armstrong, Dirk Eddelbuettel and Alfred Kanzler
 //
 //  This file is part of Rblpapi
 //
@@ -20,6 +20,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
 
+#if !defined(NoBlpHere)
 
 #include <string>
 #include <blpapi_defs.h>
@@ -194,3 +195,13 @@ SEXP authenticate_Impl(SEXP con_, SEXP uuid_, SEXP ip_address_, SEXP is_auth_id_
     if(identity_p == NULL) { Rcpp::stop("Identity pointer is null\n"); }
     return createExternalPointer<Identity>(identity_p, identityFinalizer, "blpapi::Identity*");
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+SEXP authenticate_Impl(SEXP con_, SEXP uuid_, SEXP ip_address_, SEXP is_auth_id_, SEXP app_name_) {
+    return R_NilValue;
+}
+
+#endif

--- a/src/bdh.cpp
+++ b/src/bdh.cpp
@@ -2,7 +2,7 @@
 //  bdh.cpp -- "Bloomberg Data History" query function for the BLP API
 //
 //  Copyright (C) 2013      Whit Armstrong
-//  Copyright (C) 2015-2024 Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2015-2025 Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -19,6 +19,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
 
+#if !defined(NoBlpHere)
 
 #include <vector>
 #include <string>
@@ -189,3 +190,19 @@ Rcpp::List bdh_Impl(SEXP con_,
     ans.attr("names") = ans_names;
     return ans;
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::List bdh_Impl(SEXP con_,
+                    std::vector<std::string> securities,
+                    std::vector<std::string> fields,
+                    std::string start_date_, SEXP end_date_,
+                    SEXP options_, SEXP overrides_,
+                    bool verbose, SEXP identity_,
+                    bool int_as_double) {
+    return Rcpp::List();
+}
+
+#endif

--- a/src/bdp.cpp
+++ b/src/bdp.cpp
@@ -2,7 +2,7 @@
 //  bdp.cpp -- "Bloomberg Data Point" query function for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2015 - 2025  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -19,6 +19,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
 
+#if !defined(NoBlpHere)
 
 // compare to RefDataExample.cpp
 
@@ -138,3 +139,14 @@ Rcpp::List bdp_Impl(SEXP con_, std::vector<std::string> securities, std::vector<
     }
     return res;
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::List bdp_Impl(SEXP con_, std::vector<std::string> securities, std::vector<std::string> fields,
+                    SEXP options_, SEXP overrides_, bool verbose, SEXP identity_) {
+    return Rcpp::List();
+}
+
+#endif

--- a/src/bds.cpp
+++ b/src/bds.cpp
@@ -2,7 +2,7 @@
 //  bds.cpp -- "Bloomberg Data Set" query function for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2015 - 2025  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -18,6 +18,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+#if !defined(NoBlpHere)
 
 #include <vector>
 #include <string>
@@ -295,8 +297,8 @@ Rcpp::List bds_Impl(SEXP con_, std::vector<std::string> securities,
 
 // [[Rcpp::export]]
 Rcpp::List getPortfolio_Impl(SEXP con_, std::vector<std::string> securities,
-                    std::string field, SEXP options_, SEXP overrides_,
-                    bool verbose, SEXP identity_) {
+                             std::string field, SEXP options_, SEXP overrides_,
+                             bool verbose, SEXP identity_) {
 
     Session* session =
         reinterpret_cast<Session*>(checkExternalPointer(con_, "blpapi::Session*"));
@@ -337,3 +339,21 @@ Rcpp::List getPortfolio_Impl(SEXP con_, std::vector<std::string> securities,
     }
     return R_NilValue;
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::List bds_Impl(SEXP con_, std::vector<std::string> securities,
+                    std::string field, SEXP options_, SEXP overrides_,
+                    bool verbose, SEXP identity_) {
+    return Rcpp::List();
+}
+// [[Rcpp::export]]
+Rcpp::List getPortfolio_Impl(SEXP con_, std::vector<std::string> securities,
+                             std::string field, SEXP options_, SEXP overrides_,
+                             bool verbose, SEXP identity_) {
+    return Rcpp::List();
+}
+
+#endif

--- a/src/beqs.cpp
+++ b/src/beqs.cpp
@@ -1,7 +1,7 @@
 //
 //  beqs.cpp -- "Bloomberg EQS" query function for the BLP API
 //
-//  Copyright (C) 2015-2024  Whit Armstrong and Dirk Eddelbuettel and John Laing
+//  Copyright (C) 2015-2025  Whit Armstrong and Dirk Eddelbuettel and John Laing
 //
 //  This file is part of Rblpapi
 //
@@ -19,6 +19,8 @@
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
 
 // TODO: Date, Datetime, Int (?), ... results
+
+#if !defined(NoBlpHere)
 
 #include <vector>
 #include <string>
@@ -241,3 +243,19 @@ DataFrame beqs_Impl(SEXP con,
     return ans;
 
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::DataFrame beqs_Impl(SEXP con,
+                          std::string screenName,
+                          std::string screenType,
+                          std::string group,
+                          std::string pitdate,
+                          std::string languageId,
+                          bool verbose=false) {
+    return Rcpp::DataFrame();
+}
+
+#endif

--- a/src/blpConnect.cpp
+++ b/src/blpConnect.cpp
@@ -2,9 +2,9 @@
 //
 //  blpConnect.cpp -- Function to establish Bloomberg connection
 //
-//  Copyright (C) 2013  Whit Armstrong
-//  Copyright (C) 2015  Whit Armstrong and Dirk Eddelbuettel
-//  Copyright (C) 2019  Whit Armstrong, Dirk Eddelbuettel and Alfred Kanzler
+//  Copyright (C) 2013-2025  Whit Armstrong
+//  Copyright (C) 2015-2025  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2019-2025  Whit Armstrong, Dirk Eddelbuettel and Alfred Kanzler
 //
 //  This file is part of Rblpapi
 //
@@ -20,6 +20,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+#if !defined(NoBlpHere)
 
 #include <string>
 #include <blpapi_session.h>
@@ -63,3 +65,13 @@ SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_) {
 
     return createExternalPointer<Session>(sp, sessionFinalizer, "blpapi::Session*");
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+SEXP blpConnect_Impl(const std::string host, const int port, SEXP app_name_) {
+    return R_NilValue;
+}
+
+#endif

--- a/src/blpVersion.cpp
+++ b/src/blpVersion.cpp
@@ -2,7 +2,7 @@
 //
 //  blpVersion.cpp -- Version of the Bloomberg API
 //
-//  Copyright (C) 2016  Whit Armstrong and Dirk Eddelbuettel and John Laing
+//  Copyright (C) 2016-2025  Whit Armstrong and Dirk Eddelbuettel and John Laing
 //
 //  This file is part of Rblpapi
 //
@@ -18,6 +18,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+#if !defined(NoBlpHere)
 
 #include <Rcpp.h>
 #include <blpapi_versioninfo.h>
@@ -107,3 +109,17 @@ std::string getRuntimeVersion() {
              major, minor, patch, build);
     return std::string(txt);
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+std::string getHeaderVersion() {
+    return std::string();
+}
+// [[Rcpp::export]]
+std::string getRuntimeVersion() {
+    return std::string();
+}
+
+#endif

--- a/src/blpapi_utils.cpp
+++ b/src/blpapi_utils.cpp
@@ -2,7 +2,7 @@
 //  blpapi_utils -- helper functions for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2017 - 2024  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2017 - 2025  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -18,6 +18,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+#if !defined(NoBlpHere)
 
 #include <stdexcept>
 #include <string>
@@ -446,3 +448,5 @@ Rcpp::List allocateDataFrame(size_t nrows, const vector<string>& colnames, const
   }
   return ans;
 }
+
+#endif

--- a/src/bsrch.cpp
+++ b/src/bsrch.cpp
@@ -1,7 +1,7 @@
 //
 //  bsrch.cpp -- "Bloomberg SRCH" query function for the BLP API
 //
-//  Copyright (C) 2015 - 2024  Whit Armstrong and Dirk Eddelbuettel and John Laing
+//  Copyright (C) 2015 - 2025  Whit Armstrong and Dirk Eddelbuettel and John Laing
 //
 //  This file is part of Rblpapi
 //
@@ -17,6 +17,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+#if !defined(NoBlpHere)
 
 #include <vector>
 #include <string>
@@ -175,9 +177,9 @@ Rcpp::DataFrame processBsrchResponse(Event event, const bool verbose) {
 
 // [[Rcpp::export]]
 DataFrame bsrch_Impl(SEXP con,
-                    std::string domain,
-                    std::string limit,
-                    bool verbose=false) {
+                     std::string domain,
+                     std::string limit,
+                     bool verbose=false) {
 
     Session* session = reinterpret_cast<Session*>(checkExternalPointer(con, "blpapi::Session*"));
 
@@ -226,3 +228,16 @@ DataFrame bsrch_Impl(SEXP con,
     return ans;
 
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::DataFrame bsrch_Impl(SEXP con,
+                           std::string domain,
+                           std::string limit,
+                           bool verbose=false) {
+    return Rcpp::DataFrame();
+}
+
+#endif

--- a/src/fieldsearch.cpp
+++ b/src/fieldsearch.cpp
@@ -2,7 +2,7 @@
 //  fieldsearch.cpp -- a simple field search function for the BLP API
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2014 - 2024  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2025  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -42,6 +42,7 @@
  * IN THE SOFTWARE.
  */
 
+#if !defined(NoBlpHere)
 
 #include <blpapi_session.h>
 #include <blpapi_utils.h>
@@ -118,3 +119,13 @@ Rcpp::DataFrame fieldSearch_Impl(SEXP con, std::string searchterm) {
                                    Rcpp::Named("Mnemonic")    = fieldMnen,
                                    Rcpp::Named("Description") = fieldDesc);
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::DataFrame fieldSearch_Impl(SEXP con, std::string searchterm) {
+    return Rcpp::DataFrame();
+}
+
+#endif

--- a/src/getBars.cpp
+++ b/src/getBars.cpp
@@ -2,7 +2,7 @@
 //  getBars.cpp -- a simple intraday bar retriever
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2014 - 2024  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2025  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -41,6 +41,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
+#if !defined(NoBlpHere)
 
 #include <blpapi_session.h>
 #include <blpapi_eventdispatcher.h>
@@ -224,3 +226,20 @@ Rcpp::DataFrame getBars_Impl(SEXP con,
                                    Rcpp::Named("value")     = bars.value);
 
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::DataFrame getBars_Impl(SEXP con,
+                             std::string security,
+                             std::string eventType,
+                             int barInterval,
+                             std::string startDateTime,
+                             std::string endDateTime,
+                             Rcpp::Nullable<Rcpp::CharacterVector> options,
+                             bool verbose=false) {
+    return Rcpp::DataFrame();
+}
+
+#endif

--- a/src/getFieldInfo.cpp
+++ b/src/getFieldInfo.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2016  Whit Armstrong                                    //
+// Copyright (C) 2016-2025  Whit Armstrong                                    //
 //                                                                       //
 // This program is free software: you can redistribute it and/or modify  //
 // it under the terms of the GNU General Public License as published by  //
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>. //
 ///////////////////////////////////////////////////////////////////////////
 
+#if !defined(NoBlpHere)
+
 #include <Rcpp.h>
 #include <blpapi_utils.h>
 
@@ -29,7 +31,7 @@ using BloombergLP::blpapi::Element;
 // [[Rcpp::export]]
 Rcpp::List fieldInfo_Impl(SEXP con_, std::vector<std::string> fields) {
 
-  Session* session = 
+  Session* session =
     reinterpret_cast<Session*>(checkExternalPointer(con_, "blpapi::Session*"));
 
   // get the field info
@@ -47,3 +49,13 @@ Rcpp::List fieldInfo_Impl(SEXP con_, std::vector<std::string> fields) {
   }
   return res;
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::List fieldInfo_Impl(SEXP con_, std::vector<std::string> fields) {
+    return Rcpp::List();
+}
+
+#endif

--- a/src/getTicks.cpp
+++ b/src/getTicks.cpp
@@ -2,7 +2,7 @@
 //  getTicks.cpp -- a simple intraday tick retriever
 //
 //  Copyright (C) 2013         Whit Armstrong
-//  Copyright (C) 2014 - 2024  Whit Armstrong and Dirk Eddelbuettel
+//  Copyright (C) 2014 - 2025  Whit Armstrong and Dirk Eddelbuettel
 //
 //  This file is part of Rblpapi
 //
@@ -41,6 +41,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
+#if !defined(NoBlpHere)
 
 #include <vector>
 #include <string>
@@ -205,3 +207,19 @@ Rcpp::DataFrame getTicks_Impl(SEXP con,
     	                           Rcpp::Named("condcode") = ticks.conditionCode);
 
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::DataFrame getTicks_Impl(SEXP con,
+                              std::string security,
+                              std::vector<std::string> eventType,
+                              std::string startDateTime,
+                              std::string endDateTime,
+                              bool setCondCodes=true,
+                              bool verbose=false) {
+    return Rcpp::DataFrame();
+}
+
+#endif

--- a/src/lookup.cpp
+++ b/src/lookup.cpp
@@ -1,7 +1,7 @@
 //
 //  lookup.cpp -- symbol look-up
 //
-//  Copyright (C) 2017 - 2024  Dirk Eddelbuettel and Kevin Jin
+//  Copyright (C) 2017 - 2025  Dirk Eddelbuettel and Kevin Jin
 //
 //  This file is part of Rblpapi
 //
@@ -17,6 +17,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
+
+#if !defined(NoBlpHere)
 
 #include <blpapi_session.h>
 
@@ -141,3 +143,18 @@ Rcpp::DataFrame lookup_Impl(SEXP con,
     return Rcpp::DataFrame::create(Rcpp::Named("security") = matches.security,
                                    Rcpp::Named("description") = matches.description);
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+Rcpp::DataFrame lookup_Impl(SEXP con,
+                            std::string query,
+                            std::string yellowKeyFilter="YK_FILTER_NONE",
+                            std::string languageOverride="LANG_OVERRIDE_NONE",
+                            int maxResults=20,
+                            bool verbose=false) {
+    return Rcpp::DataFrame();
+}
+
+#endif

--- a/src/subscribe.cpp
+++ b/src/subscribe.cpp
@@ -2,7 +2,7 @@
 //
 //  subscribe.cpp -- market data subscription function for the BLP API
 //
-//  Copyright (C) 2015  Whit Armstrong
+//  Copyright (C) 2015-2025  Whit Armstrong
 //
 //  This file is part of Rblpapi
 //
@@ -19,9 +19,9 @@
 //  You should have received a copy of the GNU General Public License
 //  along with Rblpapi.  If not, see <http://www.gnu.org/licenses/>.
 
+#if !defined(NoBlpHere)
 
 // compare to SimpleSubscriptionExample.cpp
-
 
 #include <iostream>
 #include <vector>
@@ -166,8 +166,8 @@ SEXP recursiveParse(const Element& e) {
 }
 
 // [[Rcpp::export]]
-SEXP subscribe_Impl(SEXP con_, std::vector<std::string> securities, std::vector<std::string> fields, Rcpp::Function fun,
-                    SEXP options_, SEXP identity_) {
+SEXP subscribe_Impl(SEXP con_, std::vector<std::string> securities, std::vector<std::string> fields,
+                    Rcpp::Function fun, SEXP options_, SEXP identity_) {
 
     // via Rcpp Attributes we get a try/catch block with error propagation to R "for free"
     Session* session =
@@ -232,3 +232,14 @@ SEXP subscribe_Impl(SEXP con_, std::vector<std::string> securities, std::vector<
     }
     return R_NilValue;
 }
+
+#else // ie if defined(NoBlpHere)
+
+#include <Rcpp/Lightest>
+// [[Rcpp::export]]
+SEXP subscribe_Impl(SEXP con_, std::vector<std::string> securities, std::vector<std::string> fields,
+                    Rcpp::Function fun, SEXP options_, SEXP identity_) {
+    return R_NilValue;
+}
+
+#endif


### PR DESCRIPTION
Fixes #405 

This addresses the issue described in #405.  We now (on Unix and alike, windows is as usual separate) only attempt to download on the two known-good setups: amd64 on linux, and arm64 on macos.  Other combinations such as the (on life-support at CRAN) older amd64 on macOS will build with `#define` indicating lack of blp support.  All exported files now have an empty fallback and just return NULL or an empty list or data.frame.  The startup message reflects this too.

No actual working configuration is changed in any way.